### PR TITLE
Solve circular imports via dependency injection

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -38,6 +38,8 @@ class ES6Exporter {
     // Copy over Reference
     es6Defs['Reference.js'] = fs.readFileSync(path.join(__dirname, 'includes', 'Reference.js'), 'utf8');
     es6Defs['json-helper.js'] = fs.readFileSync(path.join(__dirname, 'includes', 'json-helper.js'), 'utf8');
+    es6Defs['init.js'] = fs.readFileSync(path.join(__dirname, 'includes', 'init.js'), 'utf8');
+
 
     // Generate the namespace factories and specific ES6 classes
     const namespaces = this._specs.namespaces.all;

--- a/lib/includes/init.js
+++ b/lib/includes/init.js
@@ -1,0 +1,15 @@
+import {setObjectFactory} from './json-helper';
+import ObjectFactory from './ObjectFactory';
+
+/**
+ * The init function initializes the ES helper functions with the necessary dependencies for creating
+ * instances of classes using factories.  The helper functions originally imported their own dependencies,
+ * but this caused circular import issues.  This init approach is essentially a form of dependency injection,
+ * avoiding any circular import issues.  Users of the ES6 classes must import this file once before using
+ * any of the classes.
+ */
+function init() {
+  setObjectFactory(ObjectFactory);
+}
+
+init();

--- a/lib/includes/json-helper.js
+++ b/lib/includes/json-helper.js
@@ -1,10 +1,21 @@
-import ObjectFactory from './ObjectFactory';
 import Reference from './Reference';
 import Entry from './shr/base/Entry';
+
+// A variable to hold the root ObjectFactory.  This can be set via the exported setObjectFactory function,
+// but should typically be set by importing the module's init file.
+var OBJECT_FACTORY;
 
 // Regular expressions for parsing URIs and FQNs
 const URI_REGEX = /^http:\/\/standardhealthrecord\.org\/spec\/(.*)\/([^/]+)$/;
 const FQN_REGEX = /^((([a-z][0-9a-zA-Z-]*)\.)+)?([A-Z][0-9a-zA-Z-]+)$/;
+
+/**
+ * Sets the root ObjectFactory, which is needed for proper recursive creation of instances
+ * @param {ObjectFactory} factory - the root ObjectFactory used to create instances
+ */
+export function setObjectFactory(factory) {
+  OBJECT_FACTORY = factory;
+}
 
 /**
  * Parses the JSON and/or type to return an object with the namespace and elementName.
@@ -12,7 +23,7 @@ const FQN_REGEX = /^((([a-z][0-9a-zA-Z-]*)\.)+)?([A-Z][0-9a-zA-Z-]+)$/;
  * @param {string} [type] - The (optional) type of the element (e.g., 'http://standardhealthrecord.org/spec/shr/demographics/PersonOfRecord').  This is only used if the type cannot be extracted from the JSON.
  * @returns {{namespace: string, elementName: string}} An object representing the element
  */
-function getNamespaceAndName(json={}, type) {
+export function getNamespaceAndName(json={}, type) {
   // Get the type from the JSON if we can
   if (json['shr.base.EntryType']) {
     type = json['shr.base.EntryType'].Value;
@@ -47,7 +58,7 @@ function getNamespaceAndName(json={}, type) {
  * @param {object} inst - an instance of an ES6 class for a specific element
  * @param {object} json - a JSON object containing the date to set in the class
  */
-function setPropertiesFromJSON(inst, json) {
+export function setPropertiesFromJSON(inst, json) {
   // Loop through each key in the JSON, attempting to set it as a property on the class
   for (const key of Object.keys(json)) {
     // The key is an FQN (e.g., shr.foo.Bar), but the property is a lowercased version of the element name (e.g., bar)
@@ -74,7 +85,7 @@ function setPropertiesFromJSON(inst, json) {
 /**
  * Given an instance of a class and a property name, finds the setter function for that property (if it exists).
  * @param {object} inst - an instance of a class
- * @param {*} property - the name of a property
+ * @param {string} property - the name of a property
  * @returns {function} a function used to set the property on the instance
  */
 function findSetterForProperty(inst, property) {
@@ -97,7 +108,7 @@ function findSetterForProperty(inst, property) {
  * Given an instance of a class and a valid entry property name, finds the setter function for that property in the
  * class's `entryInfo` (if the class have `entryInfo` and the property exists within it).
  * @param {object} inst - An instance of a class
- * @param {*} property - The name of a property
+ * @param {string} property - The name of a property
  * @returns {function} a function used to set the property on the instance's `entryInfo`
  */
 function findSetterForEntryProperty(inst, property) {
@@ -116,9 +127,9 @@ function findSetterForEntryProperty(inst, property) {
 
 /**
  * Creates an ES6 class instance based on a value extracted from the JSON.
- * @param {*} key - the original key under which the value was stored.  This is used as a backup in case the value
+ * @param {string} key - the original key under which the value was stored.  This is used as a backup in case the value
  *   does not declare its type.
- * @param {*} value - the JSON data to create an ES6 class instance for
+ * @param {object} value - the JSON data to create an ES6 class instance for
  * @returns {object} an instance of an ES6 class representing the data
  * @private
  */
@@ -135,7 +146,10 @@ function createInstance(key, value) {
       // because in SHR, a 'code' really is *just* a string.  The JSON schema probably needs to be adjusted.
       return value.code;
     }
-    return ObjectFactory.createInstance(value, key);
+    if (OBJECT_FACTORY == null) {
+      throw new Error(`SHR ES6 module is not initialized.  Import 'init' before using the ES6 factories and classes`);
+    }
+    return OBJECT_FACTORY.createInstance(value, key);
   }
   return value;
 }
@@ -152,5 +166,3 @@ function lowerCaseFirst(input) {
   }
   return input[0].toLowerCase() + input.slice(1);
 }
-
-export {getNamespaceAndName, setPropertiesFromJSON};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-es6-export",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Exports ES6 classes represent SHR data elements",
   "author": "",
   "license": "Apache-2.0",

--- a/test/es6ClassTest.js
+++ b/test/es6ClassTest.js
@@ -6,50 +6,53 @@ require('babel-register')({
 
 setup('./test/fixtures/spec', './build/test', true);
 
-describe('#StringValueClass()', () => {
-  const StringValueEntry = importResult('shr/simple/StringValueEntry');
-  it('should construct to empty instance', () => {
-    const pv = new StringValueEntry();
-    expect(pv).instanceOf(StringValueEntry);
-    expect(pv.entryInfo).to.be.undefined;
-    expect(pv.value).to.be.undefined;
-    expect(pv.string).to.be.undefined;
+describe('#Class', () => {
+  describe('#StringValueClass()', () => {
+    const StringValueEntry = importResult('shr/simple/StringValueEntry');
+    it('should construct to empty instance', () => {
+      const pv = new StringValueEntry();
+      expect(pv).instanceOf(StringValueEntry);
+      expect(pv.entryInfo).to.be.undefined;
+      expect(pv.value).to.be.undefined;
+      expect(pv.string).to.be.undefined;
+    });
+
+    it('should get/set entryInfo', () => {
+      const pv = new StringValueEntry();
+      // NOTE: This is not a REAL Entry class, we're just testing getter/setter for now
+      pv.entryInfo = 'the entry info';
+      expect(pv.entryInfo).to.equal('the entry info');
+    });
+
+    it('should get/set value', () => {
+      const pv = new StringValueEntry();
+      pv.value = 'a value';
+      expect(pv.value).to.equal('a value');
+      // value should really be a proxy for string
+      expect(pv.string).to.equal('a value');
+    });
+
+    it('should get/set string', () => {
+      const pv = new StringValueEntry();
+      pv.string = 'a value';
+      expect(pv.string).to.equal('a value');
+      // value should really be a proxy for string
+      expect(pv.value).to.equal('a value');
+    });
   });
 
-  it('should get/set entryInfo', () => {
-    const pv = new StringValueEntry();
-    // NOTE: This is not a REAL Entry class, we're just testing getter/setter for now
-    pv.entryInfo = 'the entry info';
-    expect(pv.entryInfo).to.equal('the entry info');
+  describe('#ReservedWordEntryClass()', () => {
+    const ReservedWordEntry = importResult('shr/reserved/ReservedWordEntry');
+    it('should not use any keywords as variable names', () => {
+      // This test should have thrown an error by now if there is a reserved word violation, but just in case...
+      const pds = Object.getOwnPropertyDescriptors(ReservedWordEntry.prototype);
+      for (const rw of ['package', 'class', 'enum', 'await']) {
+        expect(pds[rw].set.toString()).to.contain(`function set(${rw}Var)`)
+          .and.to.contain(`this._${rw} = ${rw}Var;`);
+      }
+    });
   });
 
-  it('should get/set value', () => {
-    const pv = new StringValueEntry();
-    pv.value = 'a value';
-    expect(pv.value).to.equal('a value');
-    // value should really be a proxy for string
-    expect(pv.string).to.equal('a value');
-  });
-
-  it('should get/set string', () => {
-    const pv = new StringValueEntry();
-    pv.string = 'a value';
-    expect(pv.string).to.equal('a value');
-    // value should really be a proxy for string
-    expect(pv.value).to.equal('a value');
-  });
-});
-
-describe('#ReservedWordEntryClass()', () => {
-  const ReservedWordEntry = importResult('shr/reserved/ReservedWordEntry');
-  it('should not use any keywords as variable names', () => {
-    // This test should have thrown an error by now if there is a reserved word violation, but just in case...
-    const pds = Object.getOwnPropertyDescriptors(ReservedWordEntry.prototype);
-    for (const rw of ['package', 'class', 'enum', 'await']) {
-      expect(pds[rw].set.toString()).to.contain(`function set(${rw}Var)`)
-        .and.to.contain(`this._${rw} = ${rw}Var;`);
-    }
-  });
 });
 
 function importResult(path) {

--- a/test/es6FactoryTest.js
+++ b/test/es6FactoryTest.js
@@ -6,46 +6,50 @@ require('babel-register')({
 
 setup('./test/fixtures/spec', './build/test', true);
 
-describe('#ObjectFactory()', () => {
-  const ObjectFactory = importResult('ObjectFactory');
-  const StringValueEntry = importResult('shr/simple/StringValueEntry');
+describe('#Factory()', () => {
 
-  it('should create classes by name', () => {
-    const pv = ObjectFactory.createInstance({}, 'http://standardhealthrecord.org/spec/shr/simple/StringValueEntry');
-    expect(pv).instanceOf(StringValueEntry);
-    expect(pv.entryInfo).to.be.undefined;
-    expect(pv.value).to.be.undefined;
-    expect(pv.string).to.be.undefined;
+  describe('#ObjectFactory()', () => {
+    const ObjectFactory = importResult('ObjectFactory');
+    const StringValueEntry = importResult('shr/simple/StringValueEntry');
+
+    it('should create classes by name', () => {
+      const pv = ObjectFactory.createInstance({}, 'http://standardhealthrecord.org/spec/shr/simple/StringValueEntry');
+      expect(pv).instanceOf(StringValueEntry);
+      expect(pv.entryInfo).to.be.undefined;
+      expect(pv.value).to.be.undefined;
+      expect(pv.string).to.be.undefined;
+    });
+
+    it('should throw when you request an element in the wrong namespace', () => {
+      expect(() => ObjectFactory.createInstance({}, 'http://standardhealthrecord.org/spec/shr/base/StringValueEntry')).to.throw();
+    });
+
+    it('should throw when you request an unknown element', () => {
+      expect(() => ObjectFactory.createInstance({}, 'http://therealworld.org/Unicorn')).to.throw();
+    });
   });
 
-  it('should throw when you request an element in the wrong namespace', () => {
-    expect(() => ObjectFactory.createInstance({}, 'http://standardhealthrecord.org/spec/shr/base/StringValueEntry')).to.throw();
+  describe('#NamespaceObjectFactory()', () => {
+    const ShrSimpleTestObjectFactory = importResult('shr/simple/ShrSimpleObjectFactory');
+    const StringValueEntry = importResult('shr/simple/StringValueEntry');
+
+    it('should create classes by name', () => {
+      const pv = ShrSimpleTestObjectFactory.createInstance({}, 'http://standardhealthrecord.org/spec/shr/simple/StringValueEntry');
+      expect(pv).instanceOf(StringValueEntry);
+      expect(pv.entryInfo).to.be.undefined;
+      expect(pv.value).to.be.undefined;
+      expect(pv.string).to.be.undefined;
+    });
+
+    it('should throw when you request an element from a different namespace', () => {
+      expect(() => ShrSimpleTestObjectFactory.createInstance({}, 'http://standardhealthrecord.org/spec/shr/base/StringValueEntry')).to.throw();
+    });
+
+    it('should throw when you request an unknown element', () => {
+      expect(() => ShrSimpleTestObjectFactory.createInstance({}, 'http://standardhealthrecord.org/spec/shr/simple/Unicorn')).to.throw();
+    });
   });
 
-  it('should throw when you request an unknown element', () => {
-    expect(() => ObjectFactory.createInstance({}, 'http://therealworld.org/Unicorn')).to.throw();
-  });
-});
-
-describe('#NamespaceObjectFactory()', () => {
-  const ShrSimpleTestObjectFactory = importResult('shr/simple/ShrSimpleObjectFactory');
-  const StringValueEntry = importResult('shr/simple/StringValueEntry');
-
-  it('should create classes by name', () => {
-    const pv = ShrSimpleTestObjectFactory.createInstance({}, 'http://standardhealthrecord.org/spec/shr/simple/StringValueEntry');
-    expect(pv).instanceOf(StringValueEntry);
-    expect(pv.entryInfo).to.be.undefined;
-    expect(pv.value).to.be.undefined;
-    expect(pv.string).to.be.undefined;
-  });
-
-  it('should throw when you request an element from a different namespace', () => {
-    expect(() => ShrSimpleTestObjectFactory.createInstance({}, 'http://standardhealthrecord.org/spec/shr/base/StringValueEntry')).to.throw();
-  });
-
-  it('should throw when you request an unknown element', () => {
-    expect(() => ShrSimpleTestObjectFactory.createInstance({}, 'http://standardhealthrecord.org/spec/shr/simple/Unicorn')).to.throw();
-  });
 });
 
 function importResult(path) {

--- a/test/es6FromJSONTest.js
+++ b/test/es6FromJSONTest.js
@@ -9,176 +9,180 @@ require('babel-register')({
 setup('./test/fixtures/spec', './build/test', true);
 const ajv = setupAjv('./build/test/schema');
 
-describe('#StringValueEntryClass()', () => {
-  const StringValueEntry = importResult('shr/simple/StringValueEntry');
-  it('should deserialize a JSON instance', () => {
-    const json = getJSON('StringValueEntry');
-    const entry = StringValueEntry.fromJSON(json);
-    expect(entry).instanceOf(StringValueEntry);
-    expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/StringValueEntry');
-    expectStringValue(entry, 'Hello World!');
-  });
-});
+describe('#FromJSON', () => {
 
-describe('#CodeValueEntryClass()', () => {
-  const CodeValueEntry = importResult('shr/simple/CodeValueEntry');
-  it('should deserialize a JSON instance with a string code', () => {
-    const json = getJSON('CodeStringValueEntry');
-    const entry = CodeValueEntry.fromJSON(json);
-    expect(entry).instanceOf(CodeValueEntry);
-    expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/CodeValueEntry');
-    expectCodeValue(entry, 'foo');
-  });
-  it('should deserialize a JSON instance with an object code', () => {
-    const json = getJSON('CodeObjectValueEntry');
-    const entry = CodeValueEntry.fromJSON(json);
-    expect(entry).instanceOf(CodeValueEntry);
-    expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/CodeValueEntry');
-    expectCodeValue(entry, 'foo');
-  });
-});
-
-describe('#CodingValueEntryClass()', () => {
-  const CodingValueEntry = importResult('shr/simple/CodingValueEntry');
-  it('should deserialize a JSON instance with a string code', () => {
-    const json = getJSON('CodingStringValueEntry');
-    const entry = CodingValueEntry.fromJSON(json);
-    expect(entry).instanceOf(CodingValueEntry);
-    expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/CodingValueEntry');
-    expectCodingValue(entry, { code: 'foo', codeSystem: 'http://foo.org/bar', displayText: 'Foo' });
-  });
-  it('should deserialize a JSON instance with an object code', () => {
-    const json = getJSON('CodingObjectValueEntry');
-    const entry = CodingValueEntry.fromJSON(json);
-    expect(entry).instanceOf(CodingValueEntry);
-    expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/CodingValueEntry');
-    expectCodingValue(entry, { code: 'foo', codeSystem: 'http://foo.org/bar', displayText: 'Foo' });
-  });
-});
-
-describe('#CodeableConceptValueEntryClass()', () => {
-  const CodeableConceptValueEntry = importResult('shr/simple/CodeableConceptValueEntry');
-  it('should deserialize a JSON instance with a string code', () => {
-    const json = getJSON('CodeableConceptStringValueEntry');
-    const entry = CodeableConceptValueEntry.fromJSON(json);
-    expect(entry).instanceOf(CodeableConceptValueEntry);
-    expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/CodeableConceptValueEntry');
-    expectCodeableConceptValue(entry,
-      [
-        { code: 'foo', codeSystem: 'http://foo.org/bar', displayText: 'Foo' },
-        { code: 'bar', codeSystem: 'http://foo.org/bar', displayText: 'Bar' }
-      ],
-      'FooBar'
-    );
-  });
-  it('should deserialize a JSON instance with an object code', () => {
-    const json = getJSON('CodeableConceptObjectValueEntry');
-    const entry = CodeableConceptValueEntry.fromJSON(json);
-    expect(entry).instanceOf(CodeableConceptValueEntry);
-    expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/CodeableConceptValueEntry');
-    expectCodeableConceptValue(entry,
-      [
-        { code: 'foo', codeSystem: 'http://foo.org/bar', displayText: 'Foo' },
-        { code: 'bar', codeSystem: 'http://foo.org/bar', displayText: 'Bar' }
-      ],
-      'FooBar'
-    );
-  });
-});
-
-describe('#ElementValueEntryClass()', () => {
-  const ElementValueEntry = importResult('shr/simple/ElementValueEntry');
-  it('should deserialize a JSON instance', () => {
-    const json = getJSON('ElementValueEntry');
-    const entry = ElementValueEntry.fromJSON(json);
-    expect(entry).instanceOf(ElementValueEntry);
-    expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/ElementValueEntry');
-    expectInstanceOf(entry.value, 'shr/simple/StringValue');
-    expectStringValue(entry.value, 'Hello Cleveland!');
-  });
-});
-
-describe('#RecursiveEntryClass()', () => {
-  const RecursiveEntry = importResult('shr/simple/RecursiveEntry');
-  it('should deserialize a JSON instance', () => {
-    const json = getJSON('RecursiveEntry');
-    const entry = RecursiveEntry.fromJSON(json);
-    expect(entry).instanceOf(RecursiveEntry);
-    expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/RecursiveEntry');
-    expect(entry.recursiveEntry).to.have.length(2);
-    expectIntegerValue(entry, 1);
-    // Recursive child 1
-    const child1 = entry.recursiveEntry[0];
-    expect(child1).instanceOf(RecursiveEntry);
-    expectStandardEntryInfoValues(child1, 'http://standardhealthrecord.org/spec/shr/simple/RecursiveEntry');
-    expect(child1.recursiveEntry).to.have.length(1);
-    expectIntegerValue(child1, 10);
-    // Recursive grandchild 1
-    const grandchild1 = child1.recursiveEntry[0];
-    expect(grandchild1).instanceOf(RecursiveEntry);
-    expectStandardEntryInfoValues(grandchild1, 'http://standardhealthrecord.org/spec/shr/simple/RecursiveEntry');
-    expect(grandchild1.recursiveEntry).to.be.empty;
-    expectIntegerValue(grandchild1, 11);
-    // Recursive child 2
-    const child2 = entry.recursiveEntry[1];
-    expect(child2).instanceOf(RecursiveEntry);
-    expectStandardEntryInfoValues(child2, 'http://standardhealthrecord.org/spec/shr/simple/RecursiveEntry');
-    expect(child2.recursiveEntry).to.be.empty;
-    expectIntegerValue(child2, 20);
-  });
-});
-
-describe('#ReferenceEntryClass()', () => {
-  const ReferenceEntry = importResult('shr/simple/ReferenceEntry');
-  it('should deserialize a JSON instance', () => {
-    const json = getJSON('ReferenceEntry');
-    const entry = ReferenceEntry.fromJSON(json);
-    expect(entry).instanceOf(ReferenceEntry);
-    expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/ReferenceEntry');
-    expectReferenceValue(entry, {
-      shrId: '1',
-      entryId: '1-2',
-      entryType: 'http://standardhealthrecord.org/spec/shr/simple/StringValueEntry'
-    }, 'stringValueEntry');
-    const cveRefs = entry.codeValueEntry;
-    expect(cveRefs).to.have.length(2);
-    expectReference(cveRefs[0], {
-      shrId: '1',
-      entryId: '1-3',
-      entryType: 'http://standardhealthrecord.org/spec/shr/simple/CodeValueEntry'
-    });
-    expectReference(cveRefs[1], {
-      shrId: '1',
-      entryId: '1-4',
-      entryType: 'http://standardhealthrecord.org/spec/shr/simple/CodeValueEntry'
+  describe('#StringValueEntryClass()', () => {
+    const StringValueEntry = importResult('shr/simple/StringValueEntry');
+    it('should deserialize a JSON instance', () => {
+      const json = getJSON('StringValueEntry');
+      const entry = StringValueEntry.fromJSON(json);
+      expect(entry).instanceOf(StringValueEntry);
+      expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/StringValueEntry');
+      expectStringValue(entry, 'Hello World!');
     });
   });
-});
 
-describe('#BasedOnIntegerValueElementEntryClass()', () => {
-  const BasedOnIntegerValueElementEntry = importResult('shr/simple/BasedOnIntegerValueElementEntry');
-  it('should deserialize a JSON instance', () => {
-    const json = getJSON('BasedOnIntegerValueElementEntry');
-    const entry = BasedOnIntegerValueElementEntry.fromJSON(json);
-    expect(entry).instanceOf(BasedOnIntegerValueElementEntry);
-    expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/BasedOnIntegerValueElementEntry');
-    expectIntegerValue(entry, 43);
-    expectInstanceOf(entry.stringValue, 'shr/simple/StringValue');
-    expectStringValue(entry.stringValue, 'Hello!');
+  describe('#CodeValueEntryClass()', () => {
+    const CodeValueEntry = importResult('shr/simple/CodeValueEntry');
+    it('should deserialize a JSON instance with a string code', () => {
+      const json = getJSON('CodeStringValueEntry');
+      const entry = CodeValueEntry.fromJSON(json);
+      expect(entry).instanceOf(CodeValueEntry);
+      expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/CodeValueEntry');
+      expectCodeValue(entry, 'foo');
+    });
+    it('should deserialize a JSON instance with an object code', () => {
+      const json = getJSON('CodeObjectValueEntry');
+      const entry = CodeValueEntry.fromJSON(json);
+      expect(entry).instanceOf(CodeValueEntry);
+      expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/CodeValueEntry');
+      expectCodeValue(entry, 'foo');
+    });
   });
-});
 
-describe('#OverrideBasedOnIntegerValueElementEntryClass()', () => {
-  const OverrideBasedOnIntegerValueElementEntry = importResult('shr/simple/OverrideBasedOnIntegerValueElementEntry');
-  it('should deserialize a JSON instance', () => {
-    const json = getJSON('OverrideBasedOnIntegerValueElementEntry');
-    const entry = OverrideBasedOnIntegerValueElementEntry.fromJSON(json);
-    expect(entry).instanceOf(OverrideBasedOnIntegerValueElementEntry);
-    expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/OverrideBasedOnIntegerValueElementEntry');
-    expectIntegerValue(entry, 43);
-    expectInstanceOf(entry.stringValue, 'shr/simple/StringValueChild');
-    expectStringValue(entry.stringValue, 'Hello!');
+  describe('#CodingValueEntryClass()', () => {
+    const CodingValueEntry = importResult('shr/simple/CodingValueEntry');
+    it('should deserialize a JSON instance with a string code', () => {
+      const json = getJSON('CodingStringValueEntry');
+      const entry = CodingValueEntry.fromJSON(json);
+      expect(entry).instanceOf(CodingValueEntry);
+      expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/CodingValueEntry');
+      expectCodingValue(entry, { code: 'foo', codeSystem: 'http://foo.org/bar', displayText: 'Foo' });
+    });
+    it('should deserialize a JSON instance with an object code', () => {
+      const json = getJSON('CodingObjectValueEntry');
+      const entry = CodingValueEntry.fromJSON(json);
+      expect(entry).instanceOf(CodingValueEntry);
+      expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/CodingValueEntry');
+      expectCodingValue(entry, { code: 'foo', codeSystem: 'http://foo.org/bar', displayText: 'Foo' });
+    });
   });
+
+  describe('#CodeableConceptValueEntryClass()', () => {
+    const CodeableConceptValueEntry = importResult('shr/simple/CodeableConceptValueEntry');
+    it('should deserialize a JSON instance with a string code', () => {
+      const json = getJSON('CodeableConceptStringValueEntry');
+      const entry = CodeableConceptValueEntry.fromJSON(json);
+      expect(entry).instanceOf(CodeableConceptValueEntry);
+      expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/CodeableConceptValueEntry');
+      expectCodeableConceptValue(entry,
+        [
+          { code: 'foo', codeSystem: 'http://foo.org/bar', displayText: 'Foo' },
+          { code: 'bar', codeSystem: 'http://foo.org/bar', displayText: 'Bar' }
+        ],
+        'FooBar'
+      );
+    });
+    it('should deserialize a JSON instance with an object code', () => {
+      const json = getJSON('CodeableConceptObjectValueEntry');
+      const entry = CodeableConceptValueEntry.fromJSON(json);
+      expect(entry).instanceOf(CodeableConceptValueEntry);
+      expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/CodeableConceptValueEntry');
+      expectCodeableConceptValue(entry,
+        [
+          { code: 'foo', codeSystem: 'http://foo.org/bar', displayText: 'Foo' },
+          { code: 'bar', codeSystem: 'http://foo.org/bar', displayText: 'Bar' }
+        ],
+        'FooBar'
+      );
+    });
+  });
+
+  describe('#ElementValueEntryClass()', () => {
+    const ElementValueEntry = importResult('shr/simple/ElementValueEntry');
+    it('should deserialize a JSON instance', () => {
+      const json = getJSON('ElementValueEntry');
+      const entry = ElementValueEntry.fromJSON(json);
+      expect(entry).instanceOf(ElementValueEntry);
+      expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/ElementValueEntry');
+      expectInstanceOf(entry.value, 'shr/simple/StringValue');
+      expectStringValue(entry.value, 'Hello Cleveland!');
+    });
+  });
+
+  describe('#RecursiveEntryClass()', () => {
+    const RecursiveEntry = importResult('shr/simple/RecursiveEntry');
+    it('should deserialize a JSON instance', () => {
+      const json = getJSON('RecursiveEntry');
+      const entry = RecursiveEntry.fromJSON(json);
+      expect(entry).instanceOf(RecursiveEntry);
+      expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/RecursiveEntry');
+      expect(entry.recursiveEntry).to.have.length(2);
+      expectIntegerValue(entry, 1);
+      // Recursive child 1
+      const child1 = entry.recursiveEntry[0];
+      expect(child1).instanceOf(RecursiveEntry);
+      expectStandardEntryInfoValues(child1, 'http://standardhealthrecord.org/spec/shr/simple/RecursiveEntry');
+      expect(child1.recursiveEntry).to.have.length(1);
+      expectIntegerValue(child1, 10);
+      // Recursive grandchild 1
+      const grandchild1 = child1.recursiveEntry[0];
+      expect(grandchild1).instanceOf(RecursiveEntry);
+      expectStandardEntryInfoValues(grandchild1, 'http://standardhealthrecord.org/spec/shr/simple/RecursiveEntry');
+      expect(grandchild1.recursiveEntry).to.be.empty;
+      expectIntegerValue(grandchild1, 11);
+      // Recursive child 2
+      const child2 = entry.recursiveEntry[1];
+      expect(child2).instanceOf(RecursiveEntry);
+      expectStandardEntryInfoValues(child2, 'http://standardhealthrecord.org/spec/shr/simple/RecursiveEntry');
+      expect(child2.recursiveEntry).to.be.empty;
+      expectIntegerValue(child2, 20);
+    });
+  });
+
+  describe('#ReferenceEntryClass()', () => {
+    const ReferenceEntry = importResult('shr/simple/ReferenceEntry');
+    it('should deserialize a JSON instance', () => {
+      const json = getJSON('ReferenceEntry');
+      const entry = ReferenceEntry.fromJSON(json);
+      expect(entry).instanceOf(ReferenceEntry);
+      expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/ReferenceEntry');
+      expectReferenceValue(entry, {
+        shrId: '1',
+        entryId: '1-2',
+        entryType: 'http://standardhealthrecord.org/spec/shr/simple/StringValueEntry'
+      }, 'stringValueEntry');
+      const cveRefs = entry.codeValueEntry;
+      expect(cveRefs).to.have.length(2);
+      expectReference(cveRefs[0], {
+        shrId: '1',
+        entryId: '1-3',
+        entryType: 'http://standardhealthrecord.org/spec/shr/simple/CodeValueEntry'
+      });
+      expectReference(cveRefs[1], {
+        shrId: '1',
+        entryId: '1-4',
+        entryType: 'http://standardhealthrecord.org/spec/shr/simple/CodeValueEntry'
+      });
+    });
+  });
+
+  describe('#BasedOnIntegerValueElementEntryClass()', () => {
+    const BasedOnIntegerValueElementEntry = importResult('shr/simple/BasedOnIntegerValueElementEntry');
+    it('should deserialize a JSON instance', () => {
+      const json = getJSON('BasedOnIntegerValueElementEntry');
+      const entry = BasedOnIntegerValueElementEntry.fromJSON(json);
+      expect(entry).instanceOf(BasedOnIntegerValueElementEntry);
+      expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/BasedOnIntegerValueElementEntry');
+      expectIntegerValue(entry, 43);
+      expectInstanceOf(entry.stringValue, 'shr/simple/StringValue');
+      expectStringValue(entry.stringValue, 'Hello!');
+    });
+  });
+
+  describe('#OverrideBasedOnIntegerValueElementEntryClass()', () => {
+    const OverrideBasedOnIntegerValueElementEntry = importResult('shr/simple/OverrideBasedOnIntegerValueElementEntry');
+    it('should deserialize a JSON instance', () => {
+      const json = getJSON('OverrideBasedOnIntegerValueElementEntry');
+      const entry = OverrideBasedOnIntegerValueElementEntry.fromJSON(json);
+      expect(entry).instanceOf(OverrideBasedOnIntegerValueElementEntry);
+      expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/OverrideBasedOnIntegerValueElementEntry');
+      expectIntegerValue(entry, 43);
+      expectInstanceOf(entry.stringValue, 'shr/simple/StringValueChild');
+      expectStringValue(entry.stringValue, 'Hello!');
+    });
+  });
+
 });
 
 function expectInstanceOf(inst, fqn) {

--- a/test/setup.js
+++ b/test/setup.js
@@ -41,6 +41,9 @@ function setup(inDir='./test/fixtures/spec', outDir='./build/test', clean=false)
     const filename = `${schemaId.substring(baseSchemaNamespace.length+1).replace(/\//g, '.')}.schema.json`;
     fs.writeFileSync(path.join(jsonSchemaPath, filename), JSON.stringify(jsonSchemaResults[schemaId], null, 2));
   }
+
+  // Initialize the ES6 classes as required
+  require(`${path.resolve(outDir)}/es6/init`);
 }
 
 module.exports = setup;


### PR DESCRIPTION
This PR addresses a problem w/ circular imports in the current code.  In short, it gets around the problem by using dependency injection.  Rather than having the deserializer functions import the ObjectFactory, we introduce an init function that will pass the ObjectFactory to the module that has the deserialization code.  This init function only needs to be called once, and it’s called by doing a simple import:

```js
import './path/to/es6/classes/init';
```

As long as you do this import once in your code, before you use any of the factories or classes, everything should work.  You don’t need to ever import it again after that, and everything else works just like it did before.
 
This has been approved by the Flux and Curation teams.
 