### PR TITLE
Optional values cause toJSON to fail

### DIFF
--- a/lib/generateClass.js
+++ b/lib/generateClass.js
@@ -250,7 +250,9 @@ function writeToJson(def, cw) {
         cw.ln(`inst['Value'] = typeof this.value.toJSON === 'function' ? this.value.toJSON() : this.value;`);
       }
     } else if (def.value instanceof IdentifiableValue && def.value.identifier.isPrimitive) {
-      cw.ln(`inst['Value'] = this.value;`);
+      cw.bl(`if (this.value != null)`, () => {
+        cw.ln(`inst['Value'] = this.value;`);
+      });
     } else {
       generateAssignmentIfList(def.value.card, 'Value', 'value', cw);
     }

--- a/lib/generateClass.js
+++ b/lib/generateClass.js
@@ -118,6 +118,7 @@ function writeGetterAndSetter(cw, clazzName, formalDefOrName, publicSymbol, desc
   }
 
   let formalName;
+  let required = (formalDefOrName instanceof Value) ? formalDefOrName.effectiveCard.min === 1 : false;
   if (formalDefOrName instanceof ChoiceValue) {
     // Choices get a special treatment
     const options = formalDefOrName.options.filter(o => !(o instanceof TBD));
@@ -197,14 +198,20 @@ function writeGetterAndSetter(cw, clazzName, formalDefOrName, publicSymbol, desc
     .bl(`get ${publicSymbol}()`, `return this.${privateSymbol};`)
     .ln()
     .blComment(() => {
-      cw.ln(`Set the ${descriptiveName}${arrayDescriptionPostfix}.`)
-        .ln(`@param {${typeName}} ${varName} - The ${formalName}${arrayDescriptionPostfix}`);
+      cw.ln(`Set the ${descriptiveName}${arrayDescriptionPostfix}.`);
+      if (required) {
+        cw.ln('This field/value is required.');
+      }
+      cw.ln(`@param {${typeName}} ${varName} - The ${formalName}${arrayDescriptionPostfix}`);
     })
     .bl(`set ${publicSymbol}(${varName})`, `this.${privateSymbol} = ${varName};`)
     .ln()
     .blComment(() => {
-      cw.ln(`Set the ${descriptiveName}${arrayDescriptionPostfix} and return 'this' for chaining.`)
-        .ln(`@param {${typeName}} ${varName} - The ${formalName}${arrayDescriptionPostfix}`)
+      cw.ln(`Set the ${descriptiveName}${arrayDescriptionPostfix} and return 'this' for chaining.`);
+      if (required) {
+        cw.ln('This field/value is required.');
+      }
+      cw.ln(`@param {${typeName}} ${varName} - The ${formalName}${arrayDescriptionPostfix}`)
         .ln(`@returns {${clazzName}} this.`);
     })
     .bl(`with${capitalizedPublicSymbol}(${varName})`, `this.${publicSymbol} = ${varName}; return this;`)

--- a/lib/generateClass.js
+++ b/lib/generateClass.js
@@ -277,7 +277,7 @@ function writeToJson(def, cw) {
  * @param {CodeWriter} cw - The CodeWriter that's writing the class
  */
 function generateAssignmentIfList(card, jsonString, valueString, cw) {
-  cw.bl(`if (this.${valueString} !== undefined)`, () => {
+  cw.bl(`if (this.${valueString} != null)`, () => {
     if (card.isList) {
       cw.ln(`inst['${jsonString}'] = this.${valueString}.map(f => f.toJSON());`);
     } else {

--- a/lib/generateClass.js
+++ b/lib/generateClass.js
@@ -244,11 +244,13 @@ function writeToJson(def, cw) {
   if (def.value !== undefined) {
     if (def.value instanceof ChoiceValue) {
       // Choices get a special treatment
-      if (def.value.card.isList) {
-        cw.ln(`inst['Value'] = this.value.map(f => typeof f.toJSON === 'function' ? f.toJSON() : f);`);
-      } else {
-        cw.ln(`inst['Value'] = typeof this.value.toJSON === 'function' ? this.value.toJSON() : this.value;`);
-      }
+      cw.bl(`if (this.value != null)`, () => {
+        if (def.value.card.isList) {
+          cw.ln(`inst['Value'] = this.value.map(f => typeof f.toJSON === 'function' ? f.toJSON() : f);`);
+        } else {
+          cw.ln(`inst['Value'] = typeof this.value.toJSON === 'function' ? this.value.toJSON() : this.value;`);
+        }
+      });
     } else if (def.value instanceof IdentifiableValue && def.value.identifier.isPrimitive) {
       cw.bl(`if (this.value != null)`, () => {
         cw.ln(`inst['Value'] = this.value;`);

--- a/test/es6ClassTest.js
+++ b/test/es6ClassTest.js
@@ -1,4 +1,5 @@
 const {expect} = require('chai');
+const { importResult } = require('./test_utils');
 const setup = require('./setup');
 require('babel-register')({
   presets: [ 'es2015' ]
@@ -63,7 +64,3 @@ describe('#Class', () => {
   });
 
 });
-
-function importResult(path) {
-  return require(`../build/test/es6/${path}`).default;
-}

--- a/test/es6FactoryTest.js
+++ b/test/es6FactoryTest.js
@@ -1,4 +1,5 @@
 const {expect} = require('chai');
+const { importResult } = require('./test_utils');
 const setup = require('./setup');
 require('babel-register')({
   presets: [ 'es2015' ]
@@ -51,7 +52,3 @@ describe('#Factory()', () => {
   });
 
 });
-
-function importResult(path) {
-  return require(`../build/test/es6/${path}`).default;
-}

--- a/test/es6FromJSONTest.js
+++ b/test/es6FromJSONTest.js
@@ -1,20 +1,20 @@
-const fs = require('fs');
 const {expect} = require('chai');
-const Ajv = require('ajv');
 const setup = require('./setup');
+const { TestContext, importResult } = require('./test_utils');
 require('babel-register')({
   presets: [ 'es2015' ]
 });
 
 setup('./test/fixtures/spec', './build/test', true);
-const ajv = setupAjv('./build/test/schema');
+const context = new TestContext();
+context.setupAjv('./build/test/schema');
 
 describe('#FromJSON', () => {
 
   describe('#StringValueEntryClass()', () => {
     const StringValueEntry = importResult('shr/simple/StringValueEntry');
     it('should deserialize a JSON instance', () => {
-      const json = getJSON('StringValueEntry');
+      const json = context.getJSON('StringValueEntry');
       const entry = StringValueEntry.fromJSON(json);
       expect(entry).instanceOf(StringValueEntry);
       expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/StringValueEntry');
@@ -25,14 +25,14 @@ describe('#FromJSON', () => {
   describe('#CodeValueEntryClass()', () => {
     const CodeValueEntry = importResult('shr/simple/CodeValueEntry');
     it('should deserialize a JSON instance with a string code', () => {
-      const json = getJSON('CodeStringValueEntry');
+      const json = context.getJSON('CodeStringValueEntry');
       const entry = CodeValueEntry.fromJSON(json);
       expect(entry).instanceOf(CodeValueEntry);
       expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/CodeValueEntry');
       expectCodeValue(entry, 'foo');
     });
     it('should deserialize a JSON instance with an object code', () => {
-      const json = getJSON('CodeObjectValueEntry');
+      const json = context.getJSON('CodeObjectValueEntry');
       const entry = CodeValueEntry.fromJSON(json);
       expect(entry).instanceOf(CodeValueEntry);
       expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/CodeValueEntry');
@@ -43,14 +43,14 @@ describe('#FromJSON', () => {
   describe('#CodingValueEntryClass()', () => {
     const CodingValueEntry = importResult('shr/simple/CodingValueEntry');
     it('should deserialize a JSON instance with a string code', () => {
-      const json = getJSON('CodingStringValueEntry');
+      const json = context.getJSON('CodingStringValueEntry');
       const entry = CodingValueEntry.fromJSON(json);
       expect(entry).instanceOf(CodingValueEntry);
       expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/CodingValueEntry');
       expectCodingValue(entry, { code: 'foo', codeSystem: 'http://foo.org/bar', displayText: 'Foo' });
     });
     it('should deserialize a JSON instance with an object code', () => {
-      const json = getJSON('CodingObjectValueEntry');
+      const json = context.getJSON('CodingObjectValueEntry');
       const entry = CodingValueEntry.fromJSON(json);
       expect(entry).instanceOf(CodingValueEntry);
       expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/CodingValueEntry');
@@ -61,7 +61,7 @@ describe('#FromJSON', () => {
   describe('#CodeableConceptValueEntryClass()', () => {
     const CodeableConceptValueEntry = importResult('shr/simple/CodeableConceptValueEntry');
     it('should deserialize a JSON instance with a string code', () => {
-      const json = getJSON('CodeableConceptStringValueEntry');
+      const json = context.getJSON('CodeableConceptStringValueEntry');
       const entry = CodeableConceptValueEntry.fromJSON(json);
       expect(entry).instanceOf(CodeableConceptValueEntry);
       expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/CodeableConceptValueEntry');
@@ -74,7 +74,7 @@ describe('#FromJSON', () => {
       );
     });
     it('should deserialize a JSON instance with an object code', () => {
-      const json = getJSON('CodeableConceptObjectValueEntry');
+      const json = context.getJSON('CodeableConceptObjectValueEntry');
       const entry = CodeableConceptValueEntry.fromJSON(json);
       expect(entry).instanceOf(CodeableConceptValueEntry);
       expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/CodeableConceptValueEntry');
@@ -91,7 +91,7 @@ describe('#FromJSON', () => {
   describe('#ElementValueEntryClass()', () => {
     const ElementValueEntry = importResult('shr/simple/ElementValueEntry');
     it('should deserialize a JSON instance', () => {
-      const json = getJSON('ElementValueEntry');
+      const json = context.getJSON('ElementValueEntry');
       const entry = ElementValueEntry.fromJSON(json);
       expect(entry).instanceOf(ElementValueEntry);
       expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/ElementValueEntry');
@@ -103,7 +103,7 @@ describe('#FromJSON', () => {
   describe('#RecursiveEntryClass()', () => {
     const RecursiveEntry = importResult('shr/simple/RecursiveEntry');
     it('should deserialize a JSON instance', () => {
-      const json = getJSON('RecursiveEntry');
+      const json = context.getJSON('RecursiveEntry');
       const entry = RecursiveEntry.fromJSON(json);
       expect(entry).instanceOf(RecursiveEntry);
       expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/RecursiveEntry');
@@ -133,7 +133,7 @@ describe('#FromJSON', () => {
   describe('#ReferenceEntryClass()', () => {
     const ReferenceEntry = importResult('shr/simple/ReferenceEntry');
     it('should deserialize a JSON instance', () => {
-      const json = getJSON('ReferenceEntry');
+      const json = context.getJSON('ReferenceEntry');
       const entry = ReferenceEntry.fromJSON(json);
       expect(entry).instanceOf(ReferenceEntry);
       expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/ReferenceEntry');
@@ -160,7 +160,7 @@ describe('#FromJSON', () => {
   describe('#BasedOnIntegerValueElementEntryClass()', () => {
     const BasedOnIntegerValueElementEntry = importResult('shr/simple/BasedOnIntegerValueElementEntry');
     it('should deserialize a JSON instance', () => {
-      const json = getJSON('BasedOnIntegerValueElementEntry');
+      const json = context.getJSON('BasedOnIntegerValueElementEntry');
       const entry = BasedOnIntegerValueElementEntry.fromJSON(json);
       expect(entry).instanceOf(BasedOnIntegerValueElementEntry);
       expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/BasedOnIntegerValueElementEntry');
@@ -174,7 +174,7 @@ describe('#FromJSON', () => {
     const BasedOnIntegerValueElementEntry = importResult('shr/simple/InheritBasedOnIntegerValueElementEntry');
     const InheritBasedOnIntegerValueElementEntry = importResult('shr/simple/InheritBasedOnIntegerValueElementEntry');
     it('should deserialize a JSON instance', () => {
-      const json = getJSON('InheritBasedOnIntegerValueElementEntry');
+      const json = context.getJSON('InheritBasedOnIntegerValueElementEntry');
       const entry = InheritBasedOnIntegerValueElementEntry.fromJSON(json);
       expect(entry).instanceOf(InheritBasedOnIntegerValueElementEntry);
       expect(entry).instanceOf(BasedOnIntegerValueElementEntry);
@@ -187,7 +187,7 @@ describe('#FromJSON', () => {
   describe('#OverrideBasedOnIntegerValueElementEntryClass()', () => {
     const OverrideBasedOnIntegerValueElementEntry = importResult('shr/simple/OverrideBasedOnIntegerValueElementEntry');
     it('should deserialize a JSON instance', () => {
-      const json = getJSON('OverrideBasedOnIntegerValueElementEntry');
+      const json = context.getJSON('OverrideBasedOnIntegerValueElementEntry');
       const entry = OverrideBasedOnIntegerValueElementEntry.fromJSON(json);
       expect(entry).instanceOf(OverrideBasedOnIntegerValueElementEntry);
       expectStandardEntryInfoValues(entry, 'http://standardhealthrecord.org/spec/shr/simple/OverrideBasedOnIntegerValueElementEntry');
@@ -200,14 +200,14 @@ describe('#FromJSON', () => {
   describe('#ChoiceValueEntryClass()', () => {
     const ChoiceValueEntry = importResult('shr/simple/ChoiceValueEntry');
     it('should deserialize a JSON instance with a string', () => {
-      const json = getJSON('ChoiceValueStringEntry');
+      const json = context.getJSON('ChoiceValueStringEntry');
       const entry = ChoiceValueEntry.fromJSON(json);
       expect(entry).instanceOf(ChoiceValueEntry);
       expect(entry.value).to.equal('Hello!');
     });
 
     it('should deserialize a JSON instance with an integer', () => {
-      const json = getJSON('ChoiceValueIntEntry');
+      const json = context.getJSON('ChoiceValueIntEntry');
       const entry = ChoiceValueEntry.fromJSON(json);
       expect(entry).instanceOf(ChoiceValueEntry);
       expect(entry.value).to.equal(35);
@@ -326,40 +326,3 @@ function expectReferenceValue(entry, expected, alias) {
   }
 }
 
-function getJSON(name, validate=true) {
-  const json = require(`./fixtures/instances/${name}.json`);
-  if (!json) {
-    throw new Error(`No JSON found for ${name}`);
-  }
-  if (validate) {
-    if (!json['shr.base.EntryType'] || !json['shr.base.EntryType'].Value) {
-      throw new Error(`Couldn't find entry type for ${name}`);
-    }
-    const entryType = json['shr.base.EntryType'].Value;
-    const matches = entryType.match(/^http:\/\/standardhealthrecord\.org\/spec\/(.*)\/[^/]+$/);
-    if (!matches) {
-      throw new Error(`${name}'s entry type does not match expected format: ${entryType}`);
-    }
-    const schema = `${matches[1].split('/').join('.')}.schema.json`;
-    const valid = ajv.validate(schema, json);
-    expect(valid, ajv.errorsText()).to.be.true;
-  }
-  return json;
-}
-
-function importResult(path) {
-  return require(`../build/test/es6/${path}`).default;
-}
-
-function setupAjv(schemaPath='./build/test/schema') {
-  const ajv = new Ajv();
-  // Add the JSON Schema DRAFT-04 meta schema
-  ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-04.json'));
-  // Add the generated schemas
-  for (const file of fs.readdirSync(schemaPath)) {
-    if (file.endsWith('schema.json')) {
-      ajv.addSchema(require(`../${schemaPath}/${file}`), file);
-    }
-  }
-  return ajv;
-}

--- a/test/es6ToJSONTest.js
+++ b/test/es6ToJSONTest.js
@@ -1,5 +1,3 @@
-import BasedOnIntegerValueElementEntry from '../build/test/es6/shr/simple/BasedOnIntegerValueElementEntry';
-
 const {expect} = require('chai');
 const { TestContext, importResult } = require('./test_utils');
 const setup = require('./setup');
@@ -183,7 +181,7 @@ describe('#ToJSON', () => {
 
     const ChoiceValueListEntry = importResult('shr/simple/ChoiceValueListEntry');
     it('should serialize a JSON instance with a list of strings/Codings', () => {
-      testJSONRoundtrip('ChoiceValueListEntry', 'ChoiceValueListEntry', ChoiceValueListEntry)
+      testJSONRoundtrip('ChoiceValueListEntry', 'ChoiceValueListEntry', ChoiceValueListEntry);
     });
   });
 

--- a/test/es6ToJSONTest.js
+++ b/test/es6ToJSONTest.js
@@ -185,6 +185,31 @@ describe('#ToJSON', () => {
     });
   });
 
+  describe('#OptionalIntegerValueEntryClass()', () => {
+    const OptionalIntegerValueEntry = importResult('shr/simple/OptionalIntegerValueEntry');
+    it('should serialize a JSON instance with a normal integer value', () => {
+      testJSONRoundtrip('OptionalIntegerValueEntry', 'OptionalIntegerValueEntry', OptionalIntegerValueEntry);
+    });
+
+    it('should serialize a JSON instance with no value', () => {
+      testJSONRoundtrip('OptionalIntegerValueEntryBlank', 'OptionalIntegerValueEntry', OptionalIntegerValueEntry);
+    });
+
+    it('should serialize a JSON instance with a value of 0', () => {
+      testJSONRoundtrip('OptionalIntegerValueEntryZero', 'OptionalIntegerValueEntry', OptionalIntegerValueEntry);
+    });
+
+    it('should serialize a JSON instance with a null value', () => {
+      // This is special because null values are not allowed by the schema or the integer datatype.
+      const json = context.getJSON('OptionalIntegerValueEntryBlank');
+      const entry = OptionalIntegerValueEntry.fromJSON(json);
+      expect(entry).instanceOf(OptionalIntegerValueEntry);
+      entry.value = null;
+      const gen_json = entry.toJSON();
+      context.validateJSON('OptionalIntegerValueEntryBlank', gen_json);
+      expect(gen_json).to.eql(json);
+    });
+  });
 });
 
 /**

--- a/test/es6ToJSONTest.js
+++ b/test/es6ToJSONTest.js
@@ -138,6 +138,13 @@ describe('#ToJSON', () => {
       let child2_json = child2.toJSON();
       context.validateJSON('RecursiveEntry', child2_json);
       expect(gen_json).to.eql(json);
+
+      // Recursive child 2 with a null recursive entry
+      child2.recursiveEntry = null;
+      child2_json = child2.toJSON();
+      context.validateJSON('RecursiveEntry', child2_json);
+      gen_json = entry.toJSON();
+      expect(gen_json).to.eql(json);
     });
   });
 
@@ -259,6 +266,28 @@ describe('#ToJSON', () => {
 
     it('should serialize a JSON instance with a "null" value', () => {
       testJSONRoundtrip('OptionalChoiceValueEntryNullString', 'OptionalChoiceValueEntry', OptionalChoiceValueEntry);
+    });
+  });
+
+  describe('#OptionalFieldEntryClass()', () => {
+    const OptionalFieldEntry = importResult('shr/simple/OptionalFieldEntry');
+    it('should serialize a JSON instance with a normal integer value', () => {
+      testJSONRoundtrip('OptionalFieldEntry', 'OptionalFieldEntry', OptionalFieldEntry);
+    });
+
+    it('should serialize a JSON instance with no value', () => {
+      testJSONRoundtrip('OptionalFieldEntryBlank', 'OptionalFieldEntry', OptionalFieldEntry);
+    });
+
+    it('should serialize a JSON instance with a null value', () => {
+      // This is special because null values are not allowed by the schema or the integer datatype.
+      const json = context.getJSON('OptionalFieldEntryBlank');
+      const entry = OptionalFieldEntry.fromJSON(json);
+      expect(entry).instanceOf(OptionalFieldEntry);
+      entry.integerValueElement = null;
+      const gen_json = entry.toJSON();
+      context.validateJSON('OptionalFieldEntryBlank', gen_json);
+      expect(gen_json).to.eql(json);
     });
   });
 });

--- a/test/es6ToJSONTest.js
+++ b/test/es6ToJSONTest.js
@@ -239,6 +239,28 @@ describe('#ToJSON', () => {
     });
   });
 
+  describe('#OptionalElementValueEntryClass()', () => {
+    const OptionalElementValueEntry = importResult('shr/simple/OptionalElementValueEntry');
+    it('should serialize a JSON instance with a normal integer value', () => {
+      testJSONRoundtrip('OptionalElementValueEntry', 'OptionalElementValueEntry', OptionalElementValueEntry);
+    });
+
+    it('should serialize a JSON instance with no value', () => {
+      testJSONRoundtrip('OptionalElementValueEntryBlank', 'OptionalElementValueEntry', OptionalElementValueEntry);
+    });
+
+    it('should serialize a JSON instance with a value set to null', () => {
+      // This is special because null values are not allowed by the schema or the integer datatype.
+      const json = context.getJSON('OptionalElementValueEntryBlank');
+      const entry = OptionalElementValueEntry.fromJSON(json);
+      expect(entry).instanceOf(OptionalElementValueEntry);
+      entry.value = null;
+      const gen_json = entry.toJSON();
+      context.validateJSON('OptionalElementValueEntryBlank', gen_json);
+      expect(gen_json).to.eql(json);
+    });
+  });
+
   describe('#OptionalChoiceValueEntryClass()', () => {
     const OptionalChoiceValueEntry = importResult('shr/simple/OptionalChoiceValueEntry');
     it('should serialize a JSON instance with a normal value', () => {

--- a/test/es6ToJSONTest.js
+++ b/test/es6ToJSONTest.js
@@ -148,6 +148,34 @@ describe('#ToJSON', () => {
     });
   });
 
+  describe('#SingleRecursiveEntryClass()', () => {
+    const RecursiveEntry = importResult('shr/simple/RecursiveEntry');
+    const SingleRecursiveEntry = importResult('shr/simple/SingleRecursiveEntry');
+    it('should serialize a JSON instance', () => {
+      // This one is special cased because you're working with recursive entries
+      const json = context.getJSON('SingleRecursiveEntry');
+      const entry = SingleRecursiveEntry.fromJSON(json);
+      expect(entry).instanceOf(SingleRecursiveEntry);
+      let gen_json = entry.toJSON();
+      context.validateJSON('SingleRecursiveEntry', gen_json);
+      expect(gen_json).to.eql(json);
+
+      // Recursive child 1
+      const child1 = entry.recursiveEntry[0];
+      expect(child1).instanceOf(RecursiveEntry);
+      let child1_json = child1.toJSON();
+      context.validateJSON('RecursiveEntry', child1_json);
+      expect(gen_json).to.eql(json);
+
+      // Recursive grandchild 1
+      const grandchild1 = child1.recursiveEntry[0];
+      expect(grandchild1).instanceOf(SingleRecursiveEntry);
+      let grandchild1_json = grandchild1.toJSON();
+      context.validateJSON('SingleRecursiveEntry', grandchild1_json);
+      expect(gen_json).to.eql(json);
+    });
+  });
+
   describe('#ReferenceEntryClass()', () => {
     const ReferenceEntry = importResult('shr/simple/ReferenceEntry');
     it('should serialize a JSON instance', () => {

--- a/test/es6ToJSONTest.js
+++ b/test/es6ToJSONTest.js
@@ -178,10 +178,31 @@ describe('#ToJSON', () => {
     it('should serialize a JSON instance with an integer', () => {
       testJSONRoundtrip('ChoiceValueIntEntry', 'ChoiceValueEntry', ChoiceValueEntry);
     });
+  });
 
+  describe('#ChoiceValueEntryListClass()', () => {
     const ChoiceValueListEntry = importResult('shr/simple/ChoiceValueListEntry');
     it('should serialize a JSON instance with a list of strings/Codings', () => {
       testJSONRoundtrip('ChoiceValueListEntry', 'ChoiceValueListEntry', ChoiceValueListEntry);
+    });
+
+    it('should serialize a JSON instance with no value', () => {
+      testJSONRoundtrip('ChoiceValueListEntryBlank', 'ChoiceValueListEntry', ChoiceValueListEntry);
+    });
+
+    it('should serialize a JSON instance with a value of []', () => {
+      testJSONRoundtrip('ChoiceValueListEntryEmpty', 'ChoiceValueListEntryEmpty', ChoiceValueListEntry);
+    });
+
+    it('should serialize a JSON instance with a null value', () => {
+      // This is special because null values are not allowed by the schema.
+      const json = context.getJSON('ChoiceValueListEntryBlank');
+      const entry = ChoiceValueListEntry.fromJSON(json);
+      expect(entry).instanceOf(ChoiceValueListEntry);
+      entry.value = null;
+      const gen_json = entry.toJSON();
+      context.validateJSON('ChoiceValueListEntryBlank', gen_json);
+      expect(gen_json).to.eql(json);
     });
   });
 
@@ -208,6 +229,36 @@ describe('#ToJSON', () => {
       const gen_json = entry.toJSON();
       context.validateJSON('OptionalIntegerValueEntryBlank', gen_json);
       expect(gen_json).to.eql(json);
+    });
+  });
+
+  describe('#OptionalChoiceValueEntryClass()', () => {
+    const OptionalChoiceValueEntry = importResult('shr/simple/OptionalChoiceValueEntry');
+    it('should serialize a JSON instance with a normal value', () => {
+      testJSONRoundtrip('OptionalChoiceValueEntry', 'OptionalChoiceValueEntry', OptionalChoiceValueEntry);
+    });
+
+    it('should serialize a JSON instance with no value', () => {
+      testJSONRoundtrip('OptionalChoiceValueEntryBlank', 'OptionalChoiceValueEntry', OptionalChoiceValueEntry);
+    });
+
+    it('should serialize a JSON instance with a value of ""', () => {
+      testJSONRoundtrip('OptionalChoiceValueEntryEmpty', 'OptionalChoiceValueEntry', OptionalChoiceValueEntry);
+    });
+
+    it('should serialize a JSON instance with a null value', () => {
+      // This is special because null values are not allowed by the schema or the integer datatype.
+      const json = context.getJSON('OptionalChoiceValueEntryBlank');
+      const entry = OptionalChoiceValueEntry.fromJSON(json);
+      expect(entry).instanceOf(OptionalChoiceValueEntry);
+      entry.value = null;
+      const gen_json = entry.toJSON();
+      context.validateJSON('OptionalChoiceValueEntryBlank', gen_json);
+      expect(gen_json).to.eql(json);
+    });
+
+    it('should serialize a JSON instance with a "null" value', () => {
+      testJSONRoundtrip('OptionalChoiceValueEntryNullString', 'OptionalChoiceValueEntry', OptionalChoiceValueEntry);
     });
   });
 });

--- a/test/es6ToJSONTest.js
+++ b/test/es6ToJSONTest.js
@@ -123,21 +123,18 @@ describe('#ToJSON', () => {
       expect(child1).instanceOf(RecursiveEntry);
       let child1_json = child1.toJSON();
       context.validateJSON('RecursiveEntry', child1_json);
-      expect(gen_json).to.eql(json);
 
       // Recursive grandchild 1
       const grandchild1 = child1.recursiveEntry[0];
       expect(grandchild1).instanceOf(RecursiveEntry);
       let grandchild1_json = grandchild1.toJSON();
       context.validateJSON('RecursiveEntry', grandchild1_json);
-      expect(gen_json).to.eql(json);
 
       // Recursive child 2
       const child2 = entry.recursiveEntry[1];
       expect(child2).instanceOf(RecursiveEntry);
       let child2_json = child2.toJSON();
       context.validateJSON('RecursiveEntry', child2_json);
-      expect(gen_json).to.eql(json);
 
       // Recursive child 2 with a null recursive entry
       child2.recursiveEntry = null;
@@ -156,7 +153,7 @@ describe('#ToJSON', () => {
       const json = context.getJSON('SingleRecursiveEntry');
       const entry = SingleRecursiveEntry.fromJSON(json);
       expect(entry).instanceOf(SingleRecursiveEntry);
-      let gen_json = entry.toJSON();
+      const gen_json = entry.toJSON();
       context.validateJSON('SingleRecursiveEntry', gen_json);
       expect(gen_json).to.eql(json);
 
@@ -165,14 +162,12 @@ describe('#ToJSON', () => {
       expect(child1).instanceOf(RecursiveEntry);
       let child1_json = child1.toJSON();
       context.validateJSON('RecursiveEntry', child1_json);
-      expect(gen_json).to.eql(json);
 
       // Recursive grandchild 1
       const grandchild1 = child1.recursiveEntry[0];
       expect(grandchild1).instanceOf(SingleRecursiveEntry);
       let grandchild1_json = grandchild1.toJSON();
       context.validateJSON('SingleRecursiveEntry', grandchild1_json);
-      expect(gen_json).to.eql(json);
     });
   });
 

--- a/test/es6ToJSONTest.js
+++ b/test/es6ToJSONTest.js
@@ -1,15 +1,15 @@
 import BasedOnIntegerValueElementEntry from '../build/test/es6/shr/simple/BasedOnIntegerValueElementEntry';
 
-const fs = require('fs');
 const {expect} = require('chai');
-const Ajv = require('ajv');
+const { TestContext, importResult } = require('./test_utils');
 const setup = require('./setup');
 require('babel-register')({
   presets: [ 'es2015' ]
 });
 
 setup('./test/fixtures/spec', './build/test', true);
-const ajv = setupAjv('./build/test/schema');
+const context = new TestContext();
+context.setupAjv('./build/test/schema');
 
 describe('#ToJSON', () => {
   
@@ -28,12 +28,12 @@ describe('#ToJSON', () => {
     it('should serialize a JSON instance with an object code', () => {
       // This one is special-cased; this JSON doesn't roundtrip
       // because of the way Code objects are handled
-      const json = getJSON('CodeObjectValueEntry');
+      const json = context.getJSON('CodeObjectValueEntry');
       const entry = CodeValueEntry.fromJSON(json);
       expect(entry).instanceOf(CodeValueEntry);
       
       let gen_json = entry.toJSON();
-      validateJSON('CodeObjectValueEntry', gen_json);
+      context.validateJSON('CodeObjectValueEntry', gen_json);
       expect(gen_json['shr.base.EntryType']).to.eql({Value: 'http://standardhealthrecord.org/spec/shr/simple/CodeValueEntry'});
       expect(gen_json['Value']).to.equal('foo');
     });
@@ -47,13 +47,13 @@ describe('#ToJSON', () => {
     it('should serialize a JSON instance with an object code', () => {
       // This one is special-cased; this JSON doesn't roundtrip
       // because of the way Coding objects are handled
-      const json = getJSON('CodingObjectValueEntry');
+      const json = context.getJSON('CodingObjectValueEntry');
       const entry = CodingValueEntry.fromJSON(json);
       expect(entry).instanceOf(CodingValueEntry);
       
       
       let gen_json = entry.toJSON();
-      validateJSON('CodingObjectValueEntry', gen_json);
+      context.validateJSON('CodingObjectValueEntry', gen_json);
       expect(gen_json['shr.base.EntryType']).to.eql({ Value: 'http://standardhealthrecord.org/spec/shr/simple/CodingValueEntry' });
       expect(gen_json['Value']['Value']).to.eql('foo');
     });
@@ -67,12 +67,12 @@ describe('#ToJSON', () => {
     it('should serialize a JSON instance with an object code', () => {
       // This one is special-cased; this JSON doesn't roundtrip
       // because of the way Code objects are handled
-      const json = getJSON('CodeableConceptObjectValueEntry');
+      const json = context.getJSON('CodeableConceptObjectValueEntry');
       const entry = CodeableConceptValueEntry.fromJSON(json);
       expect(entry).instanceOf(CodeableConceptValueEntry);
       
       let gen_json = entry.toJSON();
-      validateJSON('CodeableConceptObjectValueEntry', gen_json);
+      context.validateJSON('CodeableConceptObjectValueEntry', gen_json);
       expect(gen_json['shr.base.EntryType']).to.eql({ Value: 'http://standardhealthrecord.org/spec/shr/simple/CodeableConceptValueEntry' });
       expect(gen_json['Value']['shr.core.Coding']).to.be.an('array');
       expect(gen_json['Value']['shr.core.Coding']).to.include({
@@ -113,32 +113,32 @@ describe('#ToJSON', () => {
     const RecursiveEntry = importResult('shr/simple/RecursiveEntry');
     it('should serialize a JSON instance', () => {
       // This one is special cased because you're working with recursive entries
-      const json = getJSON('RecursiveEntry');
+      const json = context.getJSON('RecursiveEntry');
       const entry = RecursiveEntry.fromJSON(json);
       expect(entry).instanceOf(RecursiveEntry);
       let gen_json = entry.toJSON();
-      validateJSON('RecursiveEntry', gen_json);
+      context.validateJSON('RecursiveEntry', gen_json);
       expect(gen_json).to.eql(json);
       
       // Recursive child 1
       const child1 = entry.recursiveEntry[0];
       expect(child1).instanceOf(RecursiveEntry);
       let child1_json = child1.toJSON();
-      validateJSON('RecursiveEntry', child1_json);
+      context.validateJSON('RecursiveEntry', child1_json);
       expect(gen_json).to.eql(json);
 
       // Recursive grandchild 1
       const grandchild1 = child1.recursiveEntry[0];
       expect(grandchild1).instanceOf(RecursiveEntry);
       let grandchild1_json = grandchild1.toJSON();
-      validateJSON('RecursiveEntry', grandchild1_json);
+      context.validateJSON('RecursiveEntry', grandchild1_json);
       expect(gen_json).to.eql(json);
 
       // Recursive child 2
       const child2 = entry.recursiveEntry[1];
       expect(child2).instanceOf(RecursiveEntry);
       let child2_json = child2.toJSON();
-      validateJSON('RecursiveEntry', child2_json);
+      context.validateJSON('RecursiveEntry', child2_json);
       expect(gen_json).to.eql(json);
     });
   });
@@ -196,53 +196,11 @@ describe('#ToJSON', () => {
  * @param {Object} clazz 
  */
 function testJSONRoundtrip(jsonName, validationName, clazz) {
-  const json = getJSON(jsonName);
+  const json = context.getJSON(jsonName);
   const entry = clazz.fromJSON(json);
   expect(entry).instanceOf(clazz);
 
   let gen_json = entry.toJSON();
-  validateJSON(validationName, gen_json);
+  context.validateJSON(validationName, gen_json);
   expect(gen_json).to.eql(json);
-}
-
-function validateJSON(name, json) {
-  if (!json['shr.base.EntryType'] || !json['shr.base.EntryType'].Value) {
-    throw new Error(`Couldn't find entry type for ${name}`);
-  }
-  const entryType = json['shr.base.EntryType'].Value;
-  const matches = entryType.match(/^http:\/\/standardhealthrecord\.org\/spec\/(.*)\/[^/]+$/);
-  if (!matches) {
-    throw new Error(`${name}'s entry type does not match expected format: ${entryType}`);
-  }
-  const schema = `${matches[1].split('/').join('.')}.schema.json`;
-  const valid = ajv.validate(schema, json);
-  expect(valid, ajv.errorsText()).to.be.true;
-}
-
-function getJSON(name, validate = true) {
-  const json = require(`./fixtures/instances/${name}.json`);
-  if (!json) {
-    throw new Error(`No JSON found for ${name}`);
-  }
-  if (validate) {
-    validateJSON(name, json);
-  }
-  return json;
-}
-
-function importResult(path) {
-  return require(`../build/test/es6/${path}`).default;
-}
-
-function setupAjv(schemaPath = './build/test/schema') {
-  const ajv = new Ajv();
-  // Add the JSON Schema DRAFT-04 meta schema
-  ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-04.json'));
-  // Add the generated schemas
-  for (const file of fs.readdirSync(schemaPath)) {
-    if (file.endsWith('schema.json')) {
-      ajv.addSchema(require(`../${schemaPath}/${file}`), file);
-    }
-  }
-  return ajv;
 }

--- a/test/fixtures/instances/ChoiceValueListEntryBlank.json
+++ b/test/fixtures/instances/ChoiceValueListEntryBlank.json
@@ -1,0 +1,29 @@
+{
+	"shr.base.ShrId": {
+		"Value": "patient-id",
+		"shr.base.EntryType": {
+			"Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"
+		}
+	},
+	"shr.base.EntryId": {
+		"Value": "my-id",
+		"shr.base.EntryType": {
+			"Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"
+		}
+	},
+	"shr.base.EntryType": {
+		"Value": "http://standardhealthrecord.org/spec/shr/simple/ChoiceValueListEntry"
+	},
+	"shr.core.CreationTime": {
+		"Value": "2017-11-30T12:34:56Z",
+		"shr.base.EntryType": {
+			"Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+		}
+	},
+	"shr.base.LastUpdated": {
+		"Value": "2017-11-30T12:34:56Z",
+		"shr.base.EntryType": {
+			"Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+		}
+	}
+}

--- a/test/fixtures/instances/ChoiceValueListEntryEmpty.json
+++ b/test/fixtures/instances/ChoiceValueListEntryEmpty.json
@@ -1,0 +1,30 @@
+{
+	"shr.base.ShrId": {
+		"Value": "patient-id",
+		"shr.base.EntryType": {
+			"Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"
+		}
+	},
+	"shr.base.EntryId": {
+		"Value": "my-id",
+		"shr.base.EntryType": {
+			"Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"
+		}
+	},
+	"shr.base.EntryType": {
+		"Value": "http://standardhealthrecord.org/spec/shr/simple/ChoiceValueListEntry"
+	},
+	"shr.core.CreationTime": {
+		"Value": "2017-11-30T12:34:56Z",
+		"shr.base.EntryType": {
+			"Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+		}
+	},
+	"shr.base.LastUpdated": {
+		"Value": "2017-11-30T12:34:56Z",
+		"shr.base.EntryType": {
+			"Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+		}
+	},
+	"Value": []
+}

--- a/test/fixtures/instances/OptionalChoiceValueEntry.json
+++ b/test/fixtures/instances/OptionalChoiceValueEntry.json
@@ -1,0 +1,20 @@
+{
+  "shr.base.ShrId": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+    "Value": "1"
+  },
+  "shr.base.EntryId": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+    "Value": "1-1"
+  },
+  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OptionalChoiceValueEntry" },
+  "shr.core.CreationTime": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+    "Value": "2017-11-30T12:34:56Z"
+  },
+  "shr.base.LastUpdated": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+    "Value": "2017-12-05T23:45:01Z"
+  },
+  "Value": "bananas!"
+}

--- a/test/fixtures/instances/OptionalChoiceValueEntryBlank.json
+++ b/test/fixtures/instances/OptionalChoiceValueEntryBlank.json
@@ -1,0 +1,19 @@
+{
+  "shr.base.ShrId": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+    "Value": "1"
+  },
+  "shr.base.EntryId": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+    "Value": "1-1"
+  },
+  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OptionalChoiceValueEntry" },
+  "shr.core.CreationTime": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+    "Value": "2017-11-30T12:34:56Z"
+  },
+  "shr.base.LastUpdated": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+    "Value": "2017-12-05T23:45:01Z"
+  }
+}

--- a/test/fixtures/instances/OptionalChoiceValueEntryEmpty.json
+++ b/test/fixtures/instances/OptionalChoiceValueEntryEmpty.json
@@ -1,0 +1,20 @@
+{
+  "shr.base.ShrId": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+    "Value": "1"
+  },
+  "shr.base.EntryId": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+    "Value": "1-1"
+  },
+  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OptionalChoiceValueEntry" },
+  "shr.core.CreationTime": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+    "Value": "2017-11-30T12:34:56Z"
+  },
+  "shr.base.LastUpdated": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+    "Value": "2017-12-05T23:45:01Z"
+  },
+  "Value": ""
+}

--- a/test/fixtures/instances/OptionalChoiceValueEntryNullString.json
+++ b/test/fixtures/instances/OptionalChoiceValueEntryNullString.json
@@ -1,0 +1,20 @@
+{
+  "shr.base.ShrId": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+    "Value": "1"
+  },
+  "shr.base.EntryId": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+    "Value": "1-1"
+  },
+  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OptionalChoiceValueEntry" },
+  "shr.core.CreationTime": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+    "Value": "2017-11-30T12:34:56Z"
+  },
+  "shr.base.LastUpdated": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+    "Value": "2017-12-05T23:45:01Z"
+  },
+  "Value": "null"
+}

--- a/test/fixtures/instances/OptionalElementValueEntry.json
+++ b/test/fixtures/instances/OptionalElementValueEntry.json
@@ -1,0 +1,23 @@
+{
+  "shr.base.ShrId": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+    "Value": "1"
+  },
+  "shr.base.EntryId": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+    "Value": "1-1"
+  },
+  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OptionalElementValueEntry" },
+  "shr.core.CreationTime": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+    "Value": "2017-11-30T12:34:56Z"
+  },
+  "shr.base.LastUpdated": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+    "Value": "2017-12-05T23:45:01Z"
+  },
+  "Value": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/IntegerValueElement" },
+    "Value": 5
+  }
+}

--- a/test/fixtures/instances/OptionalElementValueEntryBlank.json
+++ b/test/fixtures/instances/OptionalElementValueEntryBlank.json
@@ -1,0 +1,19 @@
+{
+  "shr.base.ShrId": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+    "Value": "1"
+  },
+  "shr.base.EntryId": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+    "Value": "1-1"
+  },
+  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OptionalElementValueEntry" },
+  "shr.core.CreationTime": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+    "Value": "2017-11-30T12:34:56Z"
+  },
+  "shr.base.LastUpdated": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+    "Value": "2017-12-05T23:45:01Z"
+  }
+}

--- a/test/fixtures/instances/OptionalFieldEntry.json
+++ b/test/fixtures/instances/OptionalFieldEntry.json
@@ -1,0 +1,23 @@
+{
+  "shr.base.ShrId": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+    "Value": "1"
+  },
+  "shr.base.EntryId": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+    "Value": "1-1"
+  },
+  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OptionalFieldEntry" },
+  "shr.core.CreationTime": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+    "Value": "2017-11-30T12:34:56Z"
+  },
+  "shr.base.LastUpdated": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+    "Value": "2017-12-05T23:45:01Z"
+  },
+  "shr.simple.IntegerValueElement": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/IntegerValueElement" },
+    "Value": 5
+  }
+}

--- a/test/fixtures/instances/OptionalFieldEntryBlank.json
+++ b/test/fixtures/instances/OptionalFieldEntryBlank.json
@@ -1,0 +1,19 @@
+{
+  "shr.base.ShrId": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+    "Value": "1"
+  },
+  "shr.base.EntryId": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+    "Value": "1-1"
+  },
+  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OptionalFieldEntry" },
+  "shr.core.CreationTime": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+    "Value": "2017-11-30T12:34:56Z"
+  },
+  "shr.base.LastUpdated": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+    "Value": "2017-12-05T23:45:01Z"
+  }
+}

--- a/test/fixtures/instances/OptionalIntegerValueEntry.json
+++ b/test/fixtures/instances/OptionalIntegerValueEntry.json
@@ -1,0 +1,20 @@
+{
+  "shr.base.ShrId": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+    "Value": "1"
+  },
+  "shr.base.EntryId": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+    "Value": "1-1"
+  },
+  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OptionalIntegerValueEntry" },
+  "shr.core.CreationTime": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+    "Value": "2017-11-30T12:34:56Z"
+  },
+  "shr.base.LastUpdated": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+    "Value": "2017-12-05T23:45:01Z"
+  },
+  "Value": 1
+}

--- a/test/fixtures/instances/OptionalIntegerValueEntryBlank.json
+++ b/test/fixtures/instances/OptionalIntegerValueEntryBlank.json
@@ -1,0 +1,19 @@
+{
+  "shr.base.ShrId": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+    "Value": "1"
+  },
+  "shr.base.EntryId": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+    "Value": "1-1"
+  },
+  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OptionalIntegerValueEntry" },
+  "shr.core.CreationTime": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+    "Value": "2017-11-30T12:34:56Z"
+  },
+  "shr.base.LastUpdated": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+    "Value": "2017-12-05T23:45:01Z"
+  }
+}

--- a/test/fixtures/instances/OptionalIntegerValueEntryZero.json
+++ b/test/fixtures/instances/OptionalIntegerValueEntryZero.json
@@ -1,0 +1,20 @@
+{
+  "shr.base.ShrId": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+    "Value": "1"
+  },
+  "shr.base.EntryId": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+    "Value": "1-1"
+  },
+  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OptionalIntegerValueEntry" },
+  "shr.core.CreationTime": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+    "Value": "2017-11-30T12:34:56Z"
+  },
+  "shr.base.LastUpdated": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+    "Value": "2017-12-05T23:45:01Z"
+  },
+  "Value": 0
+}

--- a/test/fixtures/instances/SingleRecursiveEntry.json
+++ b/test/fixtures/instances/SingleRecursiveEntry.json
@@ -1,0 +1,64 @@
+{
+  "shr.base.ShrId": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+    "Value": "1"
+  },
+  "shr.base.EntryId": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+    "Value": "1-1"
+  },
+  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/SingleRecursiveEntry" },
+  "shr.core.CreationTime": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+    "Value": "2017-11-30T12:34:56Z"
+  },
+  "shr.base.LastUpdated": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+    "Value": "2017-12-05T23:45:01Z"
+  },
+  "shr.simple.RecursiveEntry": [
+    {
+      "shr.base.ShrId": {
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+        "Value": "1"
+      },
+      "shr.base.EntryId": {
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+        "Value": "1-1"
+      },
+      "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/RecursiveEntry" },
+      "shr.core.CreationTime": {
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+        "Value": "2017-11-30T12:34:56Z"
+      },
+      "shr.base.LastUpdated": {
+        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+        "Value": "2017-12-05T23:45:01Z"
+      },
+      "shr.simple.RecursiveEntry": [
+        {
+          "shr.base.ShrId": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+            "Value": "1"
+          },
+          "shr.base.EntryId": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+            "Value": "1-1"
+          },
+          "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/SingleRecursiveEntry" },
+          "shr.core.CreationTime": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+            "Value": "2017-11-30T12:34:56Z"
+          },
+          "shr.base.LastUpdated": {
+            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+            "Value": "2017-12-05T23:45:01Z"
+          },
+          "Value": 11
+        }
+      ],
+      "Value": 10
+    }
+  ],
+  "Value": 1
+}

--- a/test/fixtures/spec/shr_simple.txt
+++ b/test/fixtures/spec/shr_simple.txt
@@ -34,6 +34,9 @@ Value:        integer
 EntryElement: OptionalIntegerValueEntry
 Value:        0..1 integer
 
+EntryElement: OptionalChoiceValueEntry
+Value:        0..1 integer or string
+
 EntryElement: BasedOnIntegerValueElementEntry
 Based on:     IntegerValueElement
 1..1          StringValue

--- a/test/fixtures/spec/shr_simple.txt
+++ b/test/fixtures/spec/shr_simple.txt
@@ -31,6 +31,9 @@ Value:        ref(StringValueEntry)
 Element:      IntegerValueElement
 Value:        integer
 
+EntryElement: OptionalIntegerValueEntry
+Value:        0..1 integer
+
 EntryElement: BasedOnIntegerValueElementEntry
 Based on:     IntegerValueElement
 1..1          StringValue

--- a/test/fixtures/spec/shr_simple.txt
+++ b/test/fixtures/spec/shr_simple.txt
@@ -37,6 +37,9 @@ Value:        0..1 integer
 EntryElement: OptionalChoiceValueEntry
 Value:        0..1 integer or string
 
+EntryElement: OptionalFieldEntry
+0..1          IntegerValueElement
+
 EntryElement: BasedOnIntegerValueElementEntry
 Based on:     IntegerValueElement
 1..1          StringValue

--- a/test/fixtures/spec/shr_simple.txt
+++ b/test/fixtures/spec/shr_simple.txt
@@ -24,6 +24,10 @@ EntryElement: RecursiveEntry
 Value:        integer
 0..*          RecursiveEntry
 
+EntryElement: SingleRecursiveEntry
+Based on:     RecursiveEntry
+0..1          RecursiveEntry
+
 EntryElement: ReferenceEntry
 Value:        ref(StringValueEntry)
 0..*          ref(CodeValueEntry)

--- a/test/fixtures/spec/shr_simple.txt
+++ b/test/fixtures/spec/shr_simple.txt
@@ -40,6 +40,9 @@ Value:        0..1 integer or string
 EntryElement: OptionalFieldEntry
 0..1          IntegerValueElement
 
+EntryElement: OptionalElementValueEntry
+Value:        0..1 IntegerValueElement
+
 EntryElement: BasedOnIntegerValueElementEntry
 Based on:     IntegerValueElement
 1..1          StringValue

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const {expect} = require('chai');
+const Ajv = require('ajv');
+
+function importResult(path) {
+  return require(`../build/test/es6/${path}`).default;
+}
+
+class TestContext {
+  validateJSON(name, json) {
+    if (!json['shr.base.EntryType'] || !json['shr.base.EntryType'].Value) {
+      throw new Error(`Couldn't find entry type for ${name}`);
+    }
+    const entryType = json['shr.base.EntryType'].Value;
+    const matches = entryType.match(/^http:\/\/standardhealthrecord\.org\/spec\/(.*)\/[^/]+$/);
+    if (!matches) {
+      throw new Error(`${name}'s entry type does not match expected format: ${entryType}`);
+    }
+    const schema = `${matches[1].split('/').join('.')}.schema.json`;
+    const valid = this._ajv.validate(schema, json);
+    expect(valid, this._ajv.errorsText()).to.be.true;
+  }
+
+  getJSON(name, validate=true) {
+    const json = require(`./fixtures/instances/${name}.json`);
+    if (!json) {
+      throw new Error(`No JSON found for ${name}`);
+    }
+    if (validate) {
+      this.validateJSON(name, json);
+    }
+    return json;
+  }
+
+  setupAjv(schemaPath='./build/test/schema') {
+    const ajv = new Ajv();
+    // Add the JSON Schema DRAFT-04 meta schema
+    ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-04.json'));
+    // Add the generated schemas
+    for (const file of fs.readdirSync(schemaPath)) {
+      if (file.endsWith('schema.json')) {
+        ajv.addSchema(require(`../${schemaPath}/${file}`), file);
+      }
+    }
+    this._ajv = ajv;
+  }
+}
+
+module.exports = { importResult, TestContext };
+


### PR DESCRIPTION
Invoking `toJSON()` on objects that have optional fields or values that are set to `null` or (in some cases) are `undefined` causes null pointer/undefined pointer errors. Or in some cases a `null` or `undefined` value will be entered into the JSON which violates the schema.

This also includes some code-deduplication in the test harness. 