### PR TITLE
Enable mapping to values and direct maps (no profile generated)

### DIFF
--- a/lib/generateClass.js
+++ b/lib/generateClass.js
@@ -302,8 +302,9 @@ function writeToFhir(def, fhir, cw) {
    /* UNCOMMENT BELOW CODE TO JAM IN DUMMY MAPPING DATA */ 
 
     // if(fhirProfile.type === 'Patient'){
-    //   const maps = fhirProfile.snapshot.element.find(f => f.path === 'Patient.active').mapping;
-    //   maps.push({'identity': 'shr', 'map': '<shr.fhir.ActiveFlag>'});
+    //   const addMapping = (path, map) => { fhirProfile.snapshot.element.find(f => f.path === path).mapping.push(map)};
+    //   addMapping('Patient.active', {'identity': 'shr', 'map': '<shr.fhir.ActiveFlag>'});
+    //   addMapping('Patient.birthDate', {'identity': 'shr', 'map': '<Value>'});
     // }
 
     for (element of fhirProfile.snapshot.element) {
@@ -314,8 +315,16 @@ function writeToFhir(def, fhir, cw) {
         if(match){
           const name = match[1].split('.').pop();
           const fhirName = element.path.split('.')[1]; // Currently only handling most basic case
-          const field = def.fields.find(f => f.identifier.name === name);
-          generateAssignmentIfListFHIR(field.card, fhirName, toSymbol(name), cw);
+          if(name === 'Value'){
+            if (def.value instanceof IdentifiableValue && def.value.identifier.isPrimitive) {
+              generateAssignmentIfListFHIR(def.value.card, fhirName, toSymbol(name), cw);
+            } else {
+              console.error('ERROR: Value referenced in mapping but none exist on this element.');
+            }
+          } else {
+            const field = def.fields.find(f => f.identifier.name === name);
+            generateAssignmentIfListFHIR(field.card, fhirName, toSymbol(name), cw);
+          }
         }
       }
     }
@@ -350,14 +359,10 @@ function generateAssignmentIfList(card, jsonString, valueString, cw) {
 
 function generateAssignmentIfListFHIR(card, jsonString, valueString, cw) {
   cw.bl(`if (this.${valueString} != null)`, () => {
-    let varName = 'inst';
-    if(jsonString !== null){
-      varName= `inst['${jsonString}']`;
-    }
     if (card.isList) {
-      cw.ln(`${varName} = this.${valueString}.map(f => f.toFHIR());`);
+      cw.ln(`inst['${jsonString}'] = this.${valueString}.map(f => f.toFHIR());`);
     } else {
-      cw.ln(`${varName} = typeof this.${valueString}.toFHIR === 'function' ? this.${valueString}.toFHIR() : this.${valueString};`);
+      cw.ln(`inst['${jsonString}'] = typeof this.${valueString}.toFHIR === 'function' ? this.${valueString}.toFHIR() : this.${valueString};`);
     }
   });
 }

--- a/test/es6ToFHIRTest.js
+++ b/test/es6ToFHIRTest.js
@@ -1,4 +1,4 @@
-// const {expect} = require('chai');
+const {expect} = require('chai');
 const { TestContext, importResult } = require('./test_utils');
 const setup = require('./setup');
 require('babel-register')({
@@ -11,13 +11,14 @@ context.setupAjvFhir('./test/fixtures/fhir-schema', 'FHIR_STU_3');
 
 describe('#ToFHIR', () => {
   
-  describe('#PatientSingleConstraintEntry()', () => {
-    const PatientSingleConstraintEntry = importResult('shr/fhir/PatientSingleConstraintEntry');
-    it('should serialize to a validated PatientSingleConstraintEntry instance', () => {
-      const json = context.getJSON('PatientSingleConstraintEntry', false);
-      const entry = PatientSingleConstraintEntry.fromJSON(json);
+  describe('#PatientConstraintsEntry()', () => {
+    const PatientConstraintsEntry = importResult('shr/fhir/PatientConstraintsEntry');
+    it('should serialize to a validated PatientConstraintsEntry instance', () => {
+      const json = context.getJSON('PatientConstraintsEntry', false);
+      const entry = PatientConstraintsEntry.fromJSON(json);
       const fhir = entry.toFHIR();
-      context.validateFHIR('PatientSingleConstraintEntry', fhir);
+      expect(fhir).is.a('object');
+      context.validateFHIR('PatientConstraintsEntry', fhir);
     });
   });
 

--- a/test/es6ToFHIRTest.js
+++ b/test/es6ToFHIRTest.js
@@ -22,4 +22,15 @@ describe('#ToFHIR', () => {
     });
   });
 
+  describe('#PatientDirectMapEntry()', () => {
+    const PatientDirectMapEntry = importResult('shr/fhir/PatientDirectMapEntry');
+    it('should serialize to a validated PatientDirectMapEntry instance', () => {
+      const json = context.getJSON('PatientDirectMapEntry', false);
+      const entry = PatientDirectMapEntry.fromJSON(json);
+      const fhir = entry.toFHIR();
+      expect(fhir).is.a('object');
+      context.validateFHIR('PatientDirectMapEntry', fhir);
+    });
+  });
+
 });

--- a/test/fixtures/fhir-schema/PatientConstraintsEntry.fhir.schema.json
+++ b/test/fixtures/fhir-schema/PatientConstraintsEntry.fhir.schema.json
@@ -1,9 +1,9 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "id": "http://standardhealth.org/fhir/json-schema/PatientSingleConstraintEntry",
-  "$ref": "#/definitions/PatientSingleConstraintEntry",
+  "id": "http://standardhealth.org/fhir/json-schema/PatientConstraintsEntry",
+  "$ref": "#/definitions/PatientConstraintsEntry",
   "definitions": {
-    "PatientSingleConstraintEntry": {
+    "PatientConstraintsEntry": {
       "description": "A simple entry that constrains a FHIR resource",
       "properties": {
         "resourceType": {
@@ -14,9 +14,13 @@
         "active": {
           "description": "Active bit",
           "type": "boolean"
+        },
+        "birthDate": {
+          "description": "birthdate",
+          "type": "string"
         }
       },
-      "required": ["resourceType", "active"]
+      "required": ["resourceType", "active", "birthDate"]
     }
   }
 }

--- a/test/fixtures/fhir-schema/PatientDirectMapEntry.fhir.schema.json
+++ b/test/fixtures/fhir-schema/PatientDirectMapEntry.fhir.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://standardhealth.org/fhir/json-schema/PatientDirectMapEntry",
+  "$ref": "#/definitions/PatientDirectMapEntry",
+  "definitions": {
+    "PatientDirectMapEntry": {
+      "description": "A simple entry that constrains a FHIR resource",
+      "properties": {
+        "resourceType": {
+          "description": "Patient resource type",
+          "type": "string",
+          "enum": ["Patient"]
+        },
+        "active": {
+          "description": "Active bit",
+          "type": "boolean"
+        }
+      },
+      "required": ["resourceType", "active"]
+    }
+  }
+}

--- a/test/fixtures/instances/PatientConstraintsEntry.json
+++ b/test/fixtures/instances/PatientConstraintsEntry.json
@@ -19,5 +19,6 @@
     "shr.base.EntryType": { "Value" : "http://standardhealthrecord.org/spec/shr/fhir/ActiveFlag" },
     "Value": true
   },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/fhir/PatientSingleConstraintEntry" }
+  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/fhir/PatientConstraintsEntry" },
+  "Value": "2017-12-05T23:45:01Z"
 }

--- a/test/fixtures/instances/PatientDirectMapEntry.json
+++ b/test/fixtures/instances/PatientDirectMapEntry.json
@@ -1,0 +1,22 @@
+{
+  "shr.base.EntryId": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+    "Value": "1-1"
+  },
+  "shr.base.ShrId": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+    "Value": "1"
+  },
+  "shr.core.CreationTime": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+    "Value": "2017-11-30T12:34:56Z"
+  },
+  "shr.base.LastUpdated": {
+    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+    "Value": "2017-12-05T23:45:01Z"
+  },
+  "shr.fhir.ActiveFlag": {
+    "shr.base.EntryType": { "Value" : "http://standardhealthrecord.org/spec/shr/fhir/ActiveFlag" },
+    "Value": true
+  }
+}

--- a/test/fixtures/spec/shr_fhir.txt
+++ b/test/fixtures/spec/shr_fhir.txt
@@ -3,8 +3,9 @@ Namespace:  shr.fhir
 
 // contains sample elements that exercise FHIR mappings
 
-EntryElement: PatientSingleConstraintEntry
-Description:	"Maps to the Patient resource with one cardinality-constrained field"
+EntryElement: PatientConstraintsEntry
+Description:	"Maps to the Patient resource with constraints"
+Value:        1..1 date
 1..1 			ActiveFlag
 
 	Element:   		ActiveFlag

--- a/test/fixtures/spec/shr_fhir_map.txt
+++ b/test/fixtures/spec/shr_fhir_map.txt
@@ -2,7 +2,8 @@ Grammar:   Map 5.0
 Namespace: shr.fhir
 Target:    FHIR_STU_3
 
-PatientSingleConstraintEntry maps to Patient:
+PatientConstraintsEntry maps to Patient:
+	Value maps to birthDate
 	ActiveFlag maps to active
 
 PatientDirectMapEntry maps to Patient:

--- a/test/setup.js
+++ b/test/setup.js
@@ -18,7 +18,7 @@ function setup(inDir='./test/fixtures/spec', outDir='./build/test', clean=false)
   const jsonSchemaResults = shrJSE.exportToJSONSchema(specs, baseSchemaNamespace, configSpecs.entryTypeURL);
 
   // Generate FHIR structure definitions
-  const fhirResults = shrFE.exportToFHIR(specs, configSpecs);
+  const fhirResults = shrFE.exportToFHIR(specs, {...configSpecs, ...{retainMapping: true}});
 
   // Generate the ES6
   const results = exportToES6(specs, fhirResults);


### PR DESCRIPTION
For mapping to values, I just made it `<Value>`, which isn't the greatest... maybe we should make it `$value` or something?

I also included tests here for the direct mapping case (where no profile is generated by default).  By far the easiest solution is for us to pass a config flag that tells the exporter to not dump profiles that are an exact match to their base resource, so we can just keep all the mapping code the same.  I pass a config variable (currently `config.retainMapping` which defaults to false) that you can pull out.