### PR TITLE
Eliminate namespaces from properties from JSON Schema

### DIFF
--- a/lib/generateClass.js
+++ b/lib/generateClass.js
@@ -241,9 +241,9 @@ function writeToJson(def, cw) {
   const url = `http://standardhealthrecord.org/spec/${def.identifier.namespace.replace('.', '/')}/${className(def.identifier.name)}`;
   if (def.isEntry) {
     cw.ln(`const inst = this._entryInfo.toJSON();`);
-    cw.ln(`inst['shr.base.EntryType'] = { 'Value' : '${url}' };`);
+    cw.ln(`inst['EntryType'] = { 'Value' : '${url}' };`);
   } else if (def.identifier.name !== 'EntryType') {
-    cw.ln(`const inst = { 'shr.base.EntryType': { 'Value' : '${url}' } };`);
+    cw.ln(`const inst = { 'EntryType': { 'Value' : '${url}' } };`);
   } else {
     cw.ln(`const inst = {};`);
   }
@@ -269,7 +269,7 @@ function writeToJson(def, cw) {
 
   for (const field of def.fields) {
     if (!(field instanceof TBD)) {
-      generateAssignmentIfList(field.card, field.identifier.fqn, toSymbol(field.identifier.name), cw);
+      generateAssignmentIfList(field.card, field.identifier.name, toSymbol(field.identifier.name), cw);
     }
   }
 

--- a/lib/includes/Reference.js
+++ b/lib/includes/Reference.js
@@ -58,9 +58,9 @@ export default class Reference {
 
   toJSON() {
     return {
-      'ShrId': this._shrId,
-      'EntryId': this._entryId,
-      'EntryType': this._entryType
+      '_ShrId': this._shrId,
+      '_EntryId': this._entryId,
+      '_EntryType': this._entryType
     };
   }
 }

--- a/lib/includes/json-helper.js
+++ b/lib/includes/json-helper.js
@@ -7,7 +7,6 @@ var OBJECT_FACTORY;
 
 // Regular expressions for parsing URIs and FQNs
 const URI_REGEX = /^http:\/\/standardhealthrecord\.org\/spec\/(.*)\/([^/]+)$/;
-const FQN_REGEX = /^((([a-z][0-9a-zA-Z-]*)\.)+)?([A-Z][0-9a-zA-Z-]+)$/;
 
 /**
  * Sets the root ObjectFactory, which is needed for proper recursive creation of instances
@@ -25,25 +24,20 @@ export function setObjectFactory(factory) {
  */
 export function getNamespaceAndName(json={}, type) {
   // Get the type from the JSON if we can
-  if (json['shr.base.EntryType']) {
-    type = json['shr.base.EntryType'].Value;
+  if (json['EntryType']) {
+    type = json['EntryType'].Value;
   }
   // Ensure we have a type before proceeding
   if (!type) {
     throw new Error(`Couldn't find type for JSON: ${JSON.stringify(json)}`);
+  } else if (type === 'EntryType') {
+    return { namespace: 'shr.base', elementName: 'EntryType' };
   }
   // Try to match on a URI
   const uriMatch = type.match(URI_REGEX);
   if (uriMatch) {
     const namespace = uriMatch[1].split('/').join('.');
     const elementName = uriMatch[2];
-    return { namespace, elementName };
-  }
-  // If matching on URI didn't succeed, try to match on FQN
-  const fqnMatch = type.match(FQN_REGEX);
-  if (fqnMatch) {
-    const namespace = fqnMatch[1].slice(0, -1);
-    const elementName = fqnMatch[4];
     return { namespace, elementName };
   }
   // No match, so throw an error
@@ -61,8 +55,8 @@ export function getNamespaceAndName(json={}, type) {
 export function setPropertiesFromJSON(inst, json) {
   // Loop through each key in the JSON, attempting to set it as a property on the class
   for (const key of Object.keys(json)) {
-    // The key is an FQN (e.g., shr.foo.Bar), but the property is a lowercased version of the element name (e.g., bar)
-    const property = lowerCaseFirst(key.match(FQN_REGEX)[4]);
+    // The key has a captialized name (e.g., Bar), but the property is a lowercased version of the element name (e.g., bar)
+    const property = lowerCaseFirst(key);
     // First try to find and set it directly on the instance
     const setter = findSetterForProperty(inst, property);
     if (setter) {
@@ -76,7 +70,7 @@ export function setPropertiesFromJSON(inst, json) {
     // If we didn't find a match directly or on entryInfo, spit an error to the console.  The exception is for
     // shr.base.EntryType, which is used to indicate the field's type in the JSON, but not necessarily always a
     // settable property in the class.
-    if (!setter && !setterOnEntry && key !== 'shr.base.EntryType') {
+    if (!setter && !setterOnEntry && key !== 'EntryType') {
       console.error(`${inst.constructor.name}: No setter for '${property}' property`);
     }
   }
@@ -138,9 +132,9 @@ function createInstance(key, value) {
     return value.map(v => createInstance(key, v));
   }
   if (typeof value === 'object') {
-    if (value.ShrId && value.EntryId && value.EntryType) {
+    if (value._ShrId && value._EntryId && value._EntryType) {
       // It's a reference, so just return the reference
-      return new Reference(value.ShrId, value.EntryId, value.EntryType);
+      return new Reference(value._ShrId, value._EntryId, value._EntryType);
     } else if (value.code && value.codeSystem) {
       // It's really the one-off representation of code.  Return just the code.  We toss codeSystem and display
       // because in SHR, a 'code' really is *just* a string.  The JSON schema probably needs to be adjusted.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-es6-export",
-  "version": "5.3.1",
+  "version": "5.4.0",
   "description": "Exports ES6 classes represent SHR data elements",
   "author": "",
   "license": "Apache-2.0",
@@ -29,7 +29,7 @@
     "fs-extra": "^4.0.2",
     "mocha": "^3.2.0",
     "shr-expand": "^5.2.6",
-    "shr-json-schema-export": "https://github.com/standardhealth/shr-json-schema-export#flux_b",
+    "shr-json-schema-export": "^5.3.0",
     "shr-models": "^5.2.2",
     "shr-test-helpers": "^5.1.1",
     "shr-text-import": "^5.2.3"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "fs-extra": "^4.0.2",
     "mocha": "^3.2.0",
     "shr-expand": "^5.2.6",
-    "shr-json-schema-export": "^5.2.0",
+    "shr-json-schema-export": "https://github.com/standardhealth/shr-json-schema-export#flux_b",
     "shr-models": "^5.2.2",
     "shr-test-helpers": "^5.1.1",
     "shr-text-import": "^5.2.3"

--- a/test/es6ToJSONTest.js
+++ b/test/es6ToJSONTest.js
@@ -32,7 +32,7 @@ describe('#ToJSON', () => {
       
       let gen_json = entry.toJSON();
       context.validateJSON('CodeObjectValueEntry', gen_json);
-      expect(gen_json['shr.base.EntryType']).to.eql({Value: 'http://standardhealthrecord.org/spec/shr/simple/CodeValueEntry'});
+      expect(gen_json['EntryType']).to.eql({Value: 'http://standardhealthrecord.org/spec/shr/simple/CodeValueEntry'});
       expect(gen_json['Value']).to.equal('foo');
     });
   });
@@ -52,7 +52,7 @@ describe('#ToJSON', () => {
       
       let gen_json = entry.toJSON();
       context.validateJSON('CodingObjectValueEntry', gen_json);
-      expect(gen_json['shr.base.EntryType']).to.eql({ Value: 'http://standardhealthrecord.org/spec/shr/simple/CodingValueEntry' });
+      expect(gen_json['EntryType']).to.eql({ Value: 'http://standardhealthrecord.org/spec/shr/simple/CodingValueEntry' });
       expect(gen_json['Value']['Value']).to.eql('foo');
     });
   });
@@ -71,28 +71,28 @@ describe('#ToJSON', () => {
       
       let gen_json = entry.toJSON();
       context.validateJSON('CodeableConceptObjectValueEntry', gen_json);
-      expect(gen_json['shr.base.EntryType']).to.eql({ Value: 'http://standardhealthrecord.org/spec/shr/simple/CodeableConceptValueEntry' });
-      expect(gen_json['Value']['shr.core.Coding']).to.be.an('array');
-      expect(gen_json['Value']['shr.core.Coding']).to.include({
-        'shr.base.EntryType': { Value: 'http://standardhealthrecord.org/spec/shr/core/Coding' },
-        'shr.core.CodeSystem': {
-          'shr.base.EntryType': { Value: 'http://standardhealthrecord.org/spec/shr/core/CodeSystem' },
+      expect(gen_json['EntryType']).to.eql({ Value: 'http://standardhealthrecord.org/spec/shr/simple/CodeableConceptValueEntry' });
+      expect(gen_json['Value']['Coding']).to.be.an('array');
+      expect(gen_json['Value']['Coding']).to.include({
+        'EntryType': { Value: 'http://standardhealthrecord.org/spec/shr/core/Coding' },
+        'CodeSystem': {
+          'EntryType': { Value: 'http://standardhealthrecord.org/spec/shr/core/CodeSystem' },
           Value: 'http://foo.org/bar'
         },
-        'shr.core.DisplayText': {
-          'shr.base.EntryType': { Value: 'http://standardhealthrecord.org/spec/shr/core/DisplayText' },
+        'DisplayText': {
+          'EntryType': { Value: 'http://standardhealthrecord.org/spec/shr/core/DisplayText' },
           Value: 'Foo'
         },
         Value: 'foo'
       });
-      expect(gen_json['Value']['shr.core.Coding']).to.include({
-        'shr.base.EntryType': { Value: 'http://standardhealthrecord.org/spec/shr/core/Coding' },
-        'shr.core.CodeSystem': {
-          'shr.base.EntryType': { Value: 'http://standardhealthrecord.org/spec/shr/core/CodeSystem' },
+      expect(gen_json['Value']['Coding']).to.include({
+        'EntryType': { Value: 'http://standardhealthrecord.org/spec/shr/core/Coding' },
+        'CodeSystem': {
+          'EntryType': { Value: 'http://standardhealthrecord.org/spec/shr/core/CodeSystem' },
           Value: 'http://foo.org/bar'
         },
-        'shr.core.DisplayText': {
-          'shr.base.EntryType': { Value: 'http://standardhealthrecord.org/spec/shr/core/DisplayText' },
+        'DisplayText': {
+          'EntryType': { Value: 'http://standardhealthrecord.org/spec/shr/core/DisplayText' },
           Value: 'Bar'
         },
         Value: 'bar'

--- a/test/fixtures/instances/BasedOnIntegerValueElementEntry.json
+++ b/test/fixtures/instances/BasedOnIntegerValueElementEntry.json
@@ -1,23 +1,23 @@
 {
-  "shr.base.ShrId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+  "ShrId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
     "Value": "1"
   },
-  "shr.base.EntryId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+  "EntryId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
     "Value": "1-1"
   },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/BasedOnIntegerValueElementEntry" },
-  "shr.core.CreationTime": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/BasedOnIntegerValueElementEntry" },
+  "CreationTime": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
     "Value": "2017-11-30T12:34:56Z"
   },
-  "shr.base.LastUpdated": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+  "LastUpdated": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
     "Value": "2017-12-05T23:45:01Z"
   },
-  "shr.simple.StringValue": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/StringValue" },
+  "StringValue": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/StringValue" },
     "Value": "Hello!"
   },
   "Value": 43

--- a/test/fixtures/instances/ChoiceValueIntEntry.json
+++ b/test/fixtures/instances/ChoiceValueIntEntry.json
@@ -1,28 +1,28 @@
 {
-	"shr.base.ShrId": {
+	"ShrId": {
 		"Value": "patient-id",
-		"shr.base.EntryType": {
+		"EntryType": {
 			"Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"
 		}
 	},
-	"shr.base.EntryId": {
+	"EntryId": {
 		"Value": "my-id",
-		"shr.base.EntryType": {
+		"EntryType": {
 			"Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"
 		}
 	},
-	"shr.base.EntryType": {
+	"EntryType": {
 		"Value": "http://standardhealthrecord.org/spec/shr/simple/ChoiceValueEntry"
 	},
-	"shr.core.CreationTime": {
+	"CreationTime": {
 		"Value": "2017-11-30T12:34:56Z",
-		"shr.base.EntryType": {
+		"EntryType": {
 			"Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
 		}
 	},
-	"shr.base.LastUpdated": {
+	"LastUpdated": {
 		"Value": "2017-11-30T12:34:56Z",
-		"shr.base.EntryType": {
+		"EntryType": {
 			"Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
 		}
 	},

--- a/test/fixtures/instances/ChoiceValueListEntry.json
+++ b/test/fixtures/instances/ChoiceValueListEntry.json
@@ -1,28 +1,28 @@
 {
-	"shr.base.ShrId": {
+	"ShrId": {
 		"Value": "patient-id",
-		"shr.base.EntryType": {
+		"EntryType": {
 			"Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"
 		}
 	},
-	"shr.base.EntryId": {
+	"EntryId": {
 		"Value": "my-id",
-		"shr.base.EntryType": {
+		"EntryType": {
 			"Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"
 		}
 	},
-	"shr.base.EntryType": {
+	"EntryType": {
 		"Value": "http://standardhealthrecord.org/spec/shr/simple/ChoiceValueListEntry"
 	},
-	"shr.core.CreationTime": {
+	"CreationTime": {
 		"Value": "2017-11-30T12:34:56Z",
-		"shr.base.EntryType": {
+		"EntryType": {
 			"Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
 		}
 	},
-	"shr.base.LastUpdated": {
+	"LastUpdated": {
 		"Value": "2017-11-30T12:34:56Z",
-		"shr.base.EntryType": {
+		"EntryType": {
 			"Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
 		}
 	},
@@ -30,7 +30,7 @@
 		"Hello!",
 		{
 			"Value": "Foo",
-			"shr.base.EntryType": {
+			"EntryType": {
 				"Value": "http://standardhealthrecord.org/spec/shr/simple/StringValue"
 			}
 		}

--- a/test/fixtures/instances/ChoiceValueListEntryBlank.json
+++ b/test/fixtures/instances/ChoiceValueListEntryBlank.json
@@ -1,28 +1,28 @@
 {
-	"shr.base.ShrId": {
+	"ShrId": {
 		"Value": "patient-id",
-		"shr.base.EntryType": {
+		"EntryType": {
 			"Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"
 		}
 	},
-	"shr.base.EntryId": {
+	"EntryId": {
 		"Value": "my-id",
-		"shr.base.EntryType": {
+		"EntryType": {
 			"Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"
 		}
 	},
-	"shr.base.EntryType": {
+	"EntryType": {
 		"Value": "http://standardhealthrecord.org/spec/shr/simple/ChoiceValueListEntry"
 	},
-	"shr.core.CreationTime": {
+	"CreationTime": {
 		"Value": "2017-11-30T12:34:56Z",
-		"shr.base.EntryType": {
+		"EntryType": {
 			"Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
 		}
 	},
-	"shr.base.LastUpdated": {
+	"LastUpdated": {
 		"Value": "2017-11-30T12:34:56Z",
-		"shr.base.EntryType": {
+		"EntryType": {
 			"Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
 		}
 	}

--- a/test/fixtures/instances/ChoiceValueListEntryEmpty.json
+++ b/test/fixtures/instances/ChoiceValueListEntryEmpty.json
@@ -1,28 +1,28 @@
 {
-	"shr.base.ShrId": {
+	"ShrId": {
 		"Value": "patient-id",
-		"shr.base.EntryType": {
+		"EntryType": {
 			"Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"
 		}
 	},
-	"shr.base.EntryId": {
+	"EntryId": {
 		"Value": "my-id",
-		"shr.base.EntryType": {
+		"EntryType": {
 			"Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"
 		}
 	},
-	"shr.base.EntryType": {
+	"EntryType": {
 		"Value": "http://standardhealthrecord.org/spec/shr/simple/ChoiceValueListEntry"
 	},
-	"shr.core.CreationTime": {
+	"CreationTime": {
 		"Value": "2017-11-30T12:34:56Z",
-		"shr.base.EntryType": {
+		"EntryType": {
 			"Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
 		}
 	},
-	"shr.base.LastUpdated": {
+	"LastUpdated": {
 		"Value": "2017-11-30T12:34:56Z",
-		"shr.base.EntryType": {
+		"EntryType": {
 			"Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
 		}
 	},

--- a/test/fixtures/instances/ChoiceValueStringEntry.json
+++ b/test/fixtures/instances/ChoiceValueStringEntry.json
@@ -1,28 +1,28 @@
 {
-	"shr.base.ShrId": {
+	"ShrId": {
 		"Value": "patient-id",
-		"shr.base.EntryType": {
+		"EntryType": {
 			"Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"
 		}
 	},
-	"shr.base.EntryId": {
+	"EntryId": {
 		"Value": "my-id",
-		"shr.base.EntryType": {
+		"EntryType": {
 			"Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"
 		}
 	},
-	"shr.base.EntryType": {
+	"EntryType": {
 		"Value": "http://standardhealthrecord.org/spec/shr/simple/ChoiceValueEntry"
 	},
-	"shr.core.CreationTime": {
+	"CreationTime": {
 		"Value": "2017-11-30T12:34:56Z",
-		"shr.base.EntryType": {
+		"EntryType": {
 			"Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
 		}
 	},
-	"shr.base.LastUpdated": {
+	"LastUpdated": {
 		"Value": "2017-11-30T12:34:56Z",
-		"shr.base.EntryType": {
+		"EntryType": {
 			"Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
 		}
 	},

--- a/test/fixtures/instances/CodeObjectValueEntry.json
+++ b/test/fixtures/instances/CodeObjectValueEntry.json
@@ -1,19 +1,19 @@
 {
-  "shr.base.ShrId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+  "ShrId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
     "Value": "1"
   },
-  "shr.base.EntryId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+  "EntryId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
     "Value": "1-1"
   },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/CodeValueEntry" },
-  "shr.core.CreationTime": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/CodeValueEntry" },
+  "CreationTime": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
     "Value": "2017-11-30T12:34:56Z"
   },
-  "shr.base.LastUpdated": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+  "LastUpdated": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
     "Value": "2017-12-05T23:45:01Z"
   },
   "Value": { "code": "foo", "codeSystem": "http://foo.org/bar", "display": "Foo" }

--- a/test/fixtures/instances/CodeStringValueEntry.json
+++ b/test/fixtures/instances/CodeStringValueEntry.json
@@ -1,19 +1,19 @@
 {
-  "shr.base.ShrId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+  "ShrId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
     "Value": "1"
   },
-  "shr.base.EntryId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+  "EntryId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
     "Value": "1-1"
   },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/CodeValueEntry" },
-  "shr.core.CreationTime": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/CodeValueEntry" },
+  "CreationTime": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
     "Value": "2017-11-30T12:34:56Z"
   },
-  "shr.base.LastUpdated": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+  "LastUpdated": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
     "Value": "2017-12-05T23:45:01Z"
   },
   "Value": "foo"

--- a/test/fixtures/instances/CodeableConceptObjectValueEntry.json
+++ b/test/fixtures/instances/CodeableConceptObjectValueEntry.json
@@ -1,51 +1,51 @@
 {
-  "shr.base.ShrId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+  "ShrId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
     "Value": "1"
   },
-  "shr.base.EntryId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+  "EntryId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
     "Value": "1-1"
   },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/CodeableConceptValueEntry" },
-  "shr.core.CreationTime": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/CodeableConceptValueEntry" },
+  "CreationTime": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
     "Value": "2017-11-30T12:34:56Z"
   },
-  "shr.base.LastUpdated": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+  "LastUpdated": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
     "Value": "2017-12-05T23:45:01Z"
   },
   "Value": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept" },
-    "shr.core.Coding": [
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept" },
+    "Coding": [
       {
-        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-        "shr.core.CodeSystem": {
-          "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"},
+        "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+        "CodeSystem": {
+          "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"},
           "Value": "http://foo.org/bar"
         },
-        "shr.core.DisplayText": {
-          "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"},
+        "DisplayText": {
+          "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"},
           "Value": "Foo"
         },
         "Value": { "code": "foo", "codeSystem": "http://foo.org/bar", "display": "Foo" }
       },
       {
-        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-        "shr.core.CodeSystem": {
-          "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"},
+        "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+        "CodeSystem": {
+          "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"},
           "Value": "http://foo.org/bar"
         },
-        "shr.core.DisplayText": {
-          "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"},
+        "DisplayText": {
+          "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"},
           "Value": "Bar"
         },
         "Value": { "code": "bar", "codeSystem": "http://foo.org/bar", "display": "Bar" }
       }
     ],
-    "shr.core.DisplayText": {
-      "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"},
+    "DisplayText": {
+      "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"},
       "Value": "FooBar"
     }
   }

--- a/test/fixtures/instances/CodeableConceptStringValueEntry.json
+++ b/test/fixtures/instances/CodeableConceptStringValueEntry.json
@@ -1,51 +1,51 @@
 {
-  "shr.base.ShrId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+  "ShrId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
     "Value": "1"
   },
-  "shr.base.EntryId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+  "EntryId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
     "Value": "1-1"
   },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/CodeableConceptValueEntry" },
-  "shr.core.CreationTime": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/CodeableConceptValueEntry" },
+  "CreationTime": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
     "Value": "2017-11-30T12:34:56Z"
   },
-  "shr.base.LastUpdated": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+  "LastUpdated": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
     "Value": "2017-12-05T23:45:01Z"
   },
   "Value": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept" },
-    "shr.core.Coding": [
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeableConcept" },
+    "Coding": [
       {
-        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-        "shr.core.CodeSystem": {
-          "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"},
+        "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+        "CodeSystem": {
+          "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"},
           "Value": "http://foo.org/bar"
         },
-        "shr.core.DisplayText": {
-          "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"},
+        "DisplayText": {
+          "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"},
           "Value": "Foo"
         },
         "Value": "foo"
       },
       {
-        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-        "shr.core.CodeSystem": {
-          "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"},
+        "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+        "CodeSystem": {
+          "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"},
           "Value": "http://foo.org/bar"
         },
-        "shr.core.DisplayText": {
-          "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"},
+        "DisplayText": {
+          "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"},
           "Value": "Bar"
         },
         "Value": "bar"
       }
     ],
-    "shr.core.DisplayText": {
-      "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"},
+    "DisplayText": {
+      "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"},
       "Value": "FooBar"
     }
   }

--- a/test/fixtures/instances/CodingObjectValueEntry.json
+++ b/test/fixtures/instances/CodingObjectValueEntry.json
@@ -1,29 +1,29 @@
 {
-  "shr.base.ShrId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+  "ShrId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
     "Value": "1"
   },
-  "shr.base.EntryId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+  "EntryId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
     "Value": "1-1"
   },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/CodingValueEntry" },
-  "shr.core.CreationTime": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/CodingValueEntry" },
+  "CreationTime": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
     "Value": "2017-11-30T12:34:56Z"
   },
-  "shr.base.LastUpdated": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+  "LastUpdated": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
     "Value": "2017-12-05T23:45:01Z"
   },
   "Value": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-    "shr.core.CodeSystem": {
-      "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"},
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+    "CodeSystem": {
+      "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"},
       "Value": "http://foo.org/bar"
     },
-    "shr.core.DisplayText": {
-      "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"},
+    "DisplayText": {
+      "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"},
       "Value": "Foo"
     },
     "Value": { "code": "foo", "codeSystem": "http://foo.org/bar", "display": "Foo" }

--- a/test/fixtures/instances/CodingStringValueEntry.json
+++ b/test/fixtures/instances/CodingStringValueEntry.json
@@ -1,29 +1,29 @@
 {
-  "shr.base.ShrId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+  "ShrId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
     "Value": "1"
   },
-  "shr.base.EntryId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+  "EntryId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
     "Value": "1-1"
   },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/CodingValueEntry" },
-  "shr.core.CreationTime": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/CodingValueEntry" },
+  "CreationTime": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
     "Value": "2017-11-30T12:34:56Z"
   },
-  "shr.base.LastUpdated": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+  "LastUpdated": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
     "Value": "2017-12-05T23:45:01Z"
   },
   "Value": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
-    "shr.core.CodeSystem": {
-      "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"},
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/Coding" },
+    "CodeSystem": {
+      "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CodeSystem"},
       "Value": "http://foo.org/bar"
     },
-    "shr.core.DisplayText": {
-      "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"},
+    "DisplayText": {
+      "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/DisplayText"},
       "Value": "Foo"
     },
     "Value": "foo"

--- a/test/fixtures/instances/ElementValueEntry.json
+++ b/test/fixtures/instances/ElementValueEntry.json
@@ -1,23 +1,23 @@
 {
-  "shr.base.ShrId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+  "ShrId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
     "Value": "1"
   },
-  "shr.base.EntryId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+  "EntryId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
     "Value": "1-1"
   },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/ElementValueEntry" },
-  "shr.core.CreationTime": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/ElementValueEntry" },
+  "CreationTime": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
     "Value": "2017-11-30T12:34:56Z"
   },
-  "shr.base.LastUpdated": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+  "LastUpdated": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
     "Value": "2017-12-05T23:45:01Z"
   },
   "Value": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/StringValue" },
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/StringValue" },
     "Value": "Hello Cleveland!"
   }
 }

--- a/test/fixtures/instances/InheritBasedOnIntegerValueElementEntry.json
+++ b/test/fixtures/instances/InheritBasedOnIntegerValueElementEntry.json
@@ -1,23 +1,23 @@
 {
-  "shr.base.ShrId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+  "ShrId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
     "Value": "1"
   },
-  "shr.base.EntryId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+  "EntryId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
     "Value": "1-1"
   },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/InheritBasedOnIntegerValueElementEntry" },
-  "shr.core.CreationTime": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/InheritBasedOnIntegerValueElementEntry" },
+  "CreationTime": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
     "Value": "2017-11-30T12:34:56Z"
   },
-  "shr.base.LastUpdated": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+  "LastUpdated": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
     "Value": "2017-12-05T23:45:01Z"
   },
-  "shr.simple.StringValue": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/StringValue" },
+  "StringValue": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/StringValue" },
     "Value": "Hello!"
   },
   "Value": 43

--- a/test/fixtures/instances/OptionalChoiceValueEntry.json
+++ b/test/fixtures/instances/OptionalChoiceValueEntry.json
@@ -1,19 +1,19 @@
 {
-  "shr.base.ShrId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+  "ShrId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
     "Value": "1"
   },
-  "shr.base.EntryId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+  "EntryId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
     "Value": "1-1"
   },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OptionalChoiceValueEntry" },
-  "shr.core.CreationTime": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OptionalChoiceValueEntry" },
+  "CreationTime": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
     "Value": "2017-11-30T12:34:56Z"
   },
-  "shr.base.LastUpdated": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+  "LastUpdated": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
     "Value": "2017-12-05T23:45:01Z"
   },
   "Value": "bananas!"

--- a/test/fixtures/instances/OptionalChoiceValueEntryBlank.json
+++ b/test/fixtures/instances/OptionalChoiceValueEntryBlank.json
@@ -1,19 +1,19 @@
 {
-  "shr.base.ShrId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+  "ShrId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
     "Value": "1"
   },
-  "shr.base.EntryId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+  "EntryId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
     "Value": "1-1"
   },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OptionalChoiceValueEntry" },
-  "shr.core.CreationTime": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OptionalChoiceValueEntry" },
+  "CreationTime": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
     "Value": "2017-11-30T12:34:56Z"
   },
-  "shr.base.LastUpdated": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+  "LastUpdated": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
     "Value": "2017-12-05T23:45:01Z"
   }
 }

--- a/test/fixtures/instances/OptionalChoiceValueEntryEmpty.json
+++ b/test/fixtures/instances/OptionalChoiceValueEntryEmpty.json
@@ -1,19 +1,19 @@
 {
-  "shr.base.ShrId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+  "ShrId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
     "Value": "1"
   },
-  "shr.base.EntryId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+  "EntryId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
     "Value": "1-1"
   },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OptionalChoiceValueEntry" },
-  "shr.core.CreationTime": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OptionalChoiceValueEntry" },
+  "CreationTime": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
     "Value": "2017-11-30T12:34:56Z"
   },
-  "shr.base.LastUpdated": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+  "LastUpdated": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
     "Value": "2017-12-05T23:45:01Z"
   },
   "Value": ""

--- a/test/fixtures/instances/OptionalChoiceValueEntryNullString.json
+++ b/test/fixtures/instances/OptionalChoiceValueEntryNullString.json
@@ -1,19 +1,19 @@
 {
-  "shr.base.ShrId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+  "ShrId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
     "Value": "1"
   },
-  "shr.base.EntryId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+  "EntryId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
     "Value": "1-1"
   },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OptionalChoiceValueEntry" },
-  "shr.core.CreationTime": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OptionalChoiceValueEntry" },
+  "CreationTime": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
     "Value": "2017-11-30T12:34:56Z"
   },
-  "shr.base.LastUpdated": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+  "LastUpdated": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
     "Value": "2017-12-05T23:45:01Z"
   },
   "Value": "null"

--- a/test/fixtures/instances/OptionalElementValueEntry.json
+++ b/test/fixtures/instances/OptionalElementValueEntry.json
@@ -1,23 +1,23 @@
 {
-  "shr.base.ShrId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+  "ShrId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
     "Value": "1"
   },
-  "shr.base.EntryId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+  "EntryId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
     "Value": "1-1"
   },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OptionalElementValueEntry" },
-  "shr.core.CreationTime": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OptionalElementValueEntry" },
+  "CreationTime": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
     "Value": "2017-11-30T12:34:56Z"
   },
-  "shr.base.LastUpdated": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+  "LastUpdated": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
     "Value": "2017-12-05T23:45:01Z"
   },
   "Value": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/IntegerValueElement" },
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/IntegerValueElement" },
     "Value": 5
   }
 }

--- a/test/fixtures/instances/OptionalElementValueEntryBlank.json
+++ b/test/fixtures/instances/OptionalElementValueEntryBlank.json
@@ -1,19 +1,19 @@
 {
-  "shr.base.ShrId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+  "ShrId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
     "Value": "1"
   },
-  "shr.base.EntryId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+  "EntryId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
     "Value": "1-1"
   },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OptionalElementValueEntry" },
-  "shr.core.CreationTime": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OptionalElementValueEntry" },
+  "CreationTime": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
     "Value": "2017-11-30T12:34:56Z"
   },
-  "shr.base.LastUpdated": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+  "LastUpdated": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
     "Value": "2017-12-05T23:45:01Z"
   }
 }

--- a/test/fixtures/instances/OptionalFieldEntry.json
+++ b/test/fixtures/instances/OptionalFieldEntry.json
@@ -1,23 +1,23 @@
 {
-  "shr.base.ShrId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+  "ShrId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
     "Value": "1"
   },
-  "shr.base.EntryId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+  "EntryId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
     "Value": "1-1"
   },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OptionalFieldEntry" },
-  "shr.core.CreationTime": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OptionalFieldEntry" },
+  "CreationTime": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
     "Value": "2017-11-30T12:34:56Z"
   },
-  "shr.base.LastUpdated": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+  "LastUpdated": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
     "Value": "2017-12-05T23:45:01Z"
   },
-  "shr.simple.IntegerValueElement": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/IntegerValueElement" },
+  "IntegerValueElement": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/IntegerValueElement" },
     "Value": 5
   }
 }

--- a/test/fixtures/instances/OptionalFieldEntryBlank.json
+++ b/test/fixtures/instances/OptionalFieldEntryBlank.json
@@ -1,19 +1,19 @@
 {
-  "shr.base.ShrId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+  "ShrId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
     "Value": "1"
   },
-  "shr.base.EntryId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+  "EntryId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
     "Value": "1-1"
   },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OptionalFieldEntry" },
-  "shr.core.CreationTime": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OptionalFieldEntry" },
+  "CreationTime": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
     "Value": "2017-11-30T12:34:56Z"
   },
-  "shr.base.LastUpdated": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+  "LastUpdated": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
     "Value": "2017-12-05T23:45:01Z"
   }
 }

--- a/test/fixtures/instances/OptionalIntegerValueEntry.json
+++ b/test/fixtures/instances/OptionalIntegerValueEntry.json
@@ -1,19 +1,19 @@
 {
-  "shr.base.ShrId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+  "ShrId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
     "Value": "1"
   },
-  "shr.base.EntryId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+  "EntryId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
     "Value": "1-1"
   },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OptionalIntegerValueEntry" },
-  "shr.core.CreationTime": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OptionalIntegerValueEntry" },
+  "CreationTime": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
     "Value": "2017-11-30T12:34:56Z"
   },
-  "shr.base.LastUpdated": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+  "LastUpdated": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
     "Value": "2017-12-05T23:45:01Z"
   },
   "Value": 1

--- a/test/fixtures/instances/OptionalIntegerValueEntryBlank.json
+++ b/test/fixtures/instances/OptionalIntegerValueEntryBlank.json
@@ -1,19 +1,19 @@
 {
-  "shr.base.ShrId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+  "ShrId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
     "Value": "1"
   },
-  "shr.base.EntryId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+  "EntryId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
     "Value": "1-1"
   },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OptionalIntegerValueEntry" },
-  "shr.core.CreationTime": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OptionalIntegerValueEntry" },
+  "CreationTime": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
     "Value": "2017-11-30T12:34:56Z"
   },
-  "shr.base.LastUpdated": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+  "LastUpdated": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
     "Value": "2017-12-05T23:45:01Z"
   }
 }

--- a/test/fixtures/instances/OptionalIntegerValueEntryZero.json
+++ b/test/fixtures/instances/OptionalIntegerValueEntryZero.json
@@ -1,19 +1,19 @@
 {
-  "shr.base.ShrId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+  "ShrId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
     "Value": "1"
   },
-  "shr.base.EntryId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+  "EntryId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
     "Value": "1-1"
   },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OptionalIntegerValueEntry" },
-  "shr.core.CreationTime": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OptionalIntegerValueEntry" },
+  "CreationTime": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
     "Value": "2017-11-30T12:34:56Z"
   },
-  "shr.base.LastUpdated": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+  "LastUpdated": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
     "Value": "2017-12-05T23:45:01Z"
   },
   "Value": 0

--- a/test/fixtures/instances/OverrideBasedOnIntegerValueElementEntry.json
+++ b/test/fixtures/instances/OverrideBasedOnIntegerValueElementEntry.json
@@ -1,23 +1,23 @@
 {
-  "shr.base.ShrId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+  "ShrId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
     "Value": "1"
   },
-  "shr.base.EntryId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+  "EntryId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
     "Value": "1-1"
   },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OverrideBasedOnIntegerValueElementEntry" },
-  "shr.core.CreationTime": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/OverrideBasedOnIntegerValueElementEntry" },
+  "CreationTime": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
     "Value": "2017-11-30T12:34:56Z"
   },
-  "shr.base.LastUpdated": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+  "LastUpdated": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
     "Value": "2017-12-05T23:45:01Z"
   },
-  "shr.simple.StringValue": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/StringValueChild" },
+  "StringValue": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/StringValueChild" },
     "Value": "Hello!"
   },
   "Value": 43

--- a/test/fixtures/instances/RecursiveEntry.json
+++ b/test/fixtures/instances/RecursiveEntry.json
@@ -1,57 +1,57 @@
 {
-  "shr.base.ShrId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+  "ShrId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
     "Value": "1"
   },
-  "shr.base.EntryId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+  "EntryId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
     "Value": "1-1"
   },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/RecursiveEntry" },
-  "shr.core.CreationTime": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/RecursiveEntry" },
+  "CreationTime": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
     "Value": "2017-11-30T12:34:56Z"
   },
-  "shr.base.LastUpdated": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+  "LastUpdated": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
     "Value": "2017-12-05T23:45:01Z"
   },
-  "shr.simple.RecursiveEntry": [
+  "RecursiveEntry": [
     {
-      "shr.base.ShrId": {
-        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+      "ShrId": {
+        "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
         "Value": "1"
       },
-      "shr.base.EntryId": {
-        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+      "EntryId": {
+        "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
         "Value": "1-1"
       },
-      "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/RecursiveEntry" },
-      "shr.core.CreationTime": {
-        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+      "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/RecursiveEntry" },
+      "CreationTime": {
+        "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
         "Value": "2017-11-30T12:34:56Z"
       },
-      "shr.base.LastUpdated": {
-        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+      "LastUpdated": {
+        "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
         "Value": "2017-12-05T23:45:01Z"
       },
-      "shr.simple.RecursiveEntry": [
+      "RecursiveEntry": [
         {
-          "shr.base.ShrId": {
-            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+          "ShrId": {
+            "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
             "Value": "1"
           },
-          "shr.base.EntryId": {
-            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+          "EntryId": {
+            "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
             "Value": "1-1"
           },
-          "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/RecursiveEntry" },
-          "shr.core.CreationTime": {
-            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+          "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/RecursiveEntry" },
+          "CreationTime": {
+            "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
             "Value": "2017-11-30T12:34:56Z"
           },
-          "shr.base.LastUpdated": {
-            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+          "LastUpdated": {
+            "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
             "Value": "2017-12-05T23:45:01Z"
           },
           "Value": 11
@@ -60,21 +60,21 @@
       "Value": 10
     },
     {
-      "shr.base.ShrId": {
-        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+      "ShrId": {
+        "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
         "Value": "1"
       },
-      "shr.base.EntryId": {
-        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+      "EntryId": {
+        "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
         "Value": "1-1"
       },
-      "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/RecursiveEntry" },
-      "shr.core.CreationTime": {
-        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+      "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/RecursiveEntry" },
+      "CreationTime": {
+        "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
         "Value": "2017-11-30T12:34:56Z"
       },
-      "shr.base.LastUpdated": {
-        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+      "LastUpdated": {
+        "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
         "Value": "2017-12-05T23:45:01Z"
       },
       "Value": 20

--- a/test/fixtures/instances/ReferenceEntry.json
+++ b/test/fixtures/instances/ReferenceEntry.json
@@ -1,36 +1,36 @@
 {
-  "shr.base.ShrId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+  "ShrId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
     "Value": "1"
   },
-  "shr.base.EntryId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+  "EntryId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
     "Value": "1-1"
   },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/ReferenceEntry" },
-  "shr.core.CreationTime": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/ReferenceEntry" },
+  "CreationTime": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
     "Value": "2017-11-30T12:34:56Z"
   },
-  "shr.base.LastUpdated": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+  "LastUpdated": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
     "Value": "2017-12-05T23:45:01Z"
   },
   "Value": {
-    "ShrId": "1",
-    "EntryId": "1-2",
-    "EntryType": "http://standardhealthrecord.org/spec/shr/simple/StringValueEntry"
+    "_ShrId": "1",
+    "_EntryId": "1-2",
+    "_EntryType": "http://standardhealthrecord.org/spec/shr/simple/StringValueEntry"
   },
-  "shr.simple.CodeValueEntry": [
+  "CodeValueEntry": [
     {
-      "ShrId": "1",
-      "EntryId": "1-3",
-      "EntryType": "http://standardhealthrecord.org/spec/shr/simple/CodeValueEntry"
+      "_ShrId": "1",
+      "_EntryId": "1-3",
+      "_EntryType": "http://standardhealthrecord.org/spec/shr/simple/CodeValueEntry"
     },
     {
-      "ShrId": "1",
-      "EntryId": "1-4",
-      "EntryType": "http://standardhealthrecord.org/spec/shr/simple/CodeValueEntry"
+      "_ShrId": "1",
+      "_EntryId": "1-4",
+      "_EntryType": "http://standardhealthrecord.org/spec/shr/simple/CodeValueEntry"
     }
   ]
 }

--- a/test/fixtures/instances/SingleRecursiveEntry.json
+++ b/test/fixtures/instances/SingleRecursiveEntry.json
@@ -1,57 +1,57 @@
 {
-  "shr.base.ShrId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+  "ShrId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
     "Value": "1"
   },
-  "shr.base.EntryId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+  "EntryId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
     "Value": "1-1"
   },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/SingleRecursiveEntry" },
-  "shr.core.CreationTime": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/SingleRecursiveEntry" },
+  "CreationTime": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
     "Value": "2017-11-30T12:34:56Z"
   },
-  "shr.base.LastUpdated": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+  "LastUpdated": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
     "Value": "2017-12-05T23:45:01Z"
   },
-  "shr.simple.RecursiveEntry": [
+  "RecursiveEntry": [
     {
-      "shr.base.ShrId": {
-        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+      "ShrId": {
+        "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
         "Value": "1"
       },
-      "shr.base.EntryId": {
-        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+      "EntryId": {
+        "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
         "Value": "1-1"
       },
-      "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/RecursiveEntry" },
-      "shr.core.CreationTime": {
-        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+      "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/RecursiveEntry" },
+      "CreationTime": {
+        "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
         "Value": "2017-11-30T12:34:56Z"
       },
-      "shr.base.LastUpdated": {
-        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+      "LastUpdated": {
+        "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
         "Value": "2017-12-05T23:45:01Z"
       },
-      "shr.simple.RecursiveEntry": [
+      "RecursiveEntry": [
         {
-          "shr.base.ShrId": {
-            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+          "ShrId": {
+            "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
             "Value": "1"
           },
-          "shr.base.EntryId": {
-            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+          "EntryId": {
+            "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
             "Value": "1-1"
           },
-          "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/SingleRecursiveEntry" },
-          "shr.core.CreationTime": {
-            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+          "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/SingleRecursiveEntry" },
+          "CreationTime": {
+            "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
             "Value": "2017-11-30T12:34:56Z"
           },
-          "shr.base.LastUpdated": {
-            "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+          "LastUpdated": {
+            "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
             "Value": "2017-12-05T23:45:01Z"
           },
           "Value": 11

--- a/test/fixtures/instances/StringValueEntry.json
+++ b/test/fixtures/instances/StringValueEntry.json
@@ -1,19 +1,19 @@
 {
-  "shr.base.ShrId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
+  "ShrId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId" },
     "Value": "1"
   },
-  "shr.base.EntryId": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
+  "EntryId": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId" },
     "Value": "1-1"
   },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/StringValueEntry" },
-  "shr.core.CreationTime": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
+  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/simple/StringValueEntry" },
+  "CreationTime": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"},
     "Value": "2017-11-30T12:34:56Z"
   },
-  "shr.base.LastUpdated": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
+  "LastUpdated": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"},
     "Value": "2017-12-05T23:45:01Z"
   },
   "Value": "Hello World!"

--- a/test/test_utils.js
+++ b/test/test_utils.js
@@ -8,10 +8,10 @@ function importResult(path) {
 
 class TestContext {
   validateJSON(name, json) {
-    if (!json['shr.base.EntryType'] || !json['shr.base.EntryType'].Value) {
+    if (!json['EntryType'] || !json['EntryType'].Value) {
       throw new Error(`Couldn't find entry type for ${name}`);
     }
-    const entryType = json['shr.base.EntryType'].Value;
+    const entryType = json['EntryType'].Value;
     const matches = entryType.match(/^http:\/\/standardhealthrecord\.org\/spec\/(.*)\/[^/]+$/);
     if (!matches) {
       throw new Error(`${name}'s entry type does not match expected format: ${entryType}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1390,9 +1390,9 @@ shr-expand@^5.2.6:
   version "5.2.6"
   resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.2.6.tgz#47b82c0eb31c974e9fcfcdfc6938952804ac3bdb"
 
-shr-json-schema-export@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/shr-json-schema-export/-/shr-json-schema-export-5.2.0.tgz#02910ee6c0de23e910b01047224edea441c9fc68"
+shr-json-schema-export@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/shr-json-schema-export/-/shr-json-schema-export-5.3.0.tgz#2b1f1dd918381c23b4ebbca9946c0dc85dc227ce"
 
 shr-models@^5.2.2:
   version "5.2.2"


### PR DESCRIPTION
This removes namespaces from the element properties in the JSON Schema (and obviously the serialized form of the ES6 classes) as previously discussed.

One unexpected change required prepending `_`s to the field names of references because of how fromJson() determines what is a reference.
