### PR TITLE
Accomodate refactored config file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-es6-export",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "description": "Exports ES6 classes represent SHR data elements",
   "author": "",
   "license": "Apache-2.0",
@@ -28,11 +28,11 @@
     "eslint": "^4.15.0",
     "fs-extra": "^4.0.2",
     "mocha": "^3.2.0",
-    "shr-expand": "^5.2.6",
+    "shr-expand": "^5.5.1",
     "shr-json-schema-export": "^5.3.0",
-    "shr-models": "^5.2.2",
-    "shr-test-helpers": "^5.1.1",
-    "shr-text-import": "^5.2.3"
+    "shr-models": "^5.5.2",
+    "shr-test-helpers": "^5.1.3",
+    "shr-text-import": "^5.4.0"
   },
   "peerDependencies": {
     "shr-models": "^5.2.2"

--- a/test/fixtures/spec/config.json
+++ b/test/fixtures/spec/config.json
@@ -4,7 +4,9 @@
     "projectURL": "http://es6-export.com",
     "fhirURL": "http://es6-export.com/fhir",
     "entryTypeURL": "http://es6-export.com/spec",
-    "igIndexContent": "es6ExportIndexContent.html",
+    "implementationGuide": {
+      "indexContent": "es6ExportIndexContent.html"
+    },
     "publisher": "SHR Testers",
     "contact": [
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -808,6 +808,14 @@ fs-extra@^4.0.2:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-5.0.0.tgz#414d0110cdd06705734d055652c5411260c31abd"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -1386,25 +1394,27 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-shr-expand@^5.2.6:
-  version "5.2.6"
-  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.2.6.tgz#47b82c0eb31c974e9fcfcdfc6938952804ac3bdb"
+shr-expand@^5.5.1:
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.5.1.tgz#e8d3c0cebe9bf05d663f2e90d7ff439b39f1a82c"
 
 shr-json-schema-export@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/shr-json-schema-export/-/shr-json-schema-export-5.3.0.tgz#2b1f1dd918381c23b4ebbca9946c0dc85dc227ce"
 
-shr-models@^5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.2.2.tgz#42b9f13deded480628529e22bca09af546f8ba81"
+shr-models@^5.5.2:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.5.2.tgz#8871fa8626278a53dc729fc04512aaf2acf91b94"
 
-shr-test-helpers@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/shr-test-helpers/-/shr-test-helpers-5.1.1.tgz#e649cab3685f76bd25eca590d0949fd162b43f9f"
+shr-test-helpers@^5.1.3:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/shr-test-helpers/-/shr-test-helpers-5.2.0.tgz#8bb0982c53b1ce7d4e792bdf1cf73d94bde650f8"
+  dependencies:
+    fs-extra "^5.0.0"
 
-shr-text-import@^5.2.3:
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/shr-text-import/-/shr-text-import-5.2.3.tgz#0af683af80e1580fc84226b1a9376f075da6dfc3"
+shr-text-import@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/shr-text-import/-/shr-text-import-5.4.0.tgz#9b131b279e2af6aad61709b13ea0f2286a229487"
   dependencies:
     antlr4 "~4.6.0"
 


### PR DESCRIPTION
PR 5 of 5 for config-updates. The remaining are in `shr_spec`, `shr-cli`, `shr-text-import`, and `shr-fhir-export`.

These PRs implement:
-A refactored configuration file
-A split between primary selection strategy and filter strategy
-The ability to select a configuration file from the command line
-Added documentation in shr-cli for configuration file usage