### PR TITLE
To fhir slicing

### DIFF
--- a/lib/generateClass.js
+++ b/lib/generateClass.js
@@ -1,5 +1,5 @@
 const reserved = require('reserved-words');
-const {Value, IdentifiableValue, RefValue, ChoiceValue, TBD, INHERITED, Identifier} = require('shr-models');
+const { Value, IdentifiableValue, RefValue, ChoiceValue, TBD, INHERITED, Identifier } = require('shr-models');
 const CodeWriter = require('./CodeWriter');
 const { sanitizeName, className } = require('./common.js');
 
@@ -17,7 +17,6 @@ function generateClass(def, fhir) {
     if (def.basedOn.length > 1) {
       console.error('ERROR: Can create proper inheritance tree w/ multiple based on elements.  Using first element.');
     }
-
     if (def.basedOn[0] instanceof TBD) {
       cw.ln(`// Ommitting import and extension of base element: ${def.basedOn[0]}`).ln();
     } else {
@@ -296,6 +295,7 @@ function writeToFhir(def, fhir, cw) {
 
   const fhirProfile = [...fhir.profiles, ...fhir._noDiffProfiles].find(p => p.id === fhirID(def.identifier));
   const fhirExtension = fhir.extensions.find(p => p.id === fhirID(def.identifier, 'extension'));
+  const alreadyMappedElements = new Map;
 
   cw.ln(`let inst = {};`);
 
@@ -333,12 +333,13 @@ function writeToFhir(def, fhir, cw) {
 
     for (let element of fhirProfile.snapshot.element) {
       const mapping = element.mapping && element.mapping.find(m => m['identity'] === 'shr');
-      const baseIsList = element.base && element.base.max == '*' && element.max == '1';
+      let baseIsList = element.base && element.base.max == '*' && element.max == '1';
+      baseIsList = baseIsList || (element.mapping && element.mapping.filter(elem => elem.identity == 'shr').length > 1);
       if(mapping !== undefined){
         if(mapping.map === '<Value>'){
           // Mapping to the value of this es6 instance
           if (def.value instanceof IdentifiableValue && def.value.identifier.isPrimitive) {
-            generateFHIRAssignment(def.value.card.isList, baseIsList, element.path, 'value', cw);
+            generateFHIRAssignment(def.value.card.isList, baseIsList, 1, element.path, 'value', fhirProfile, cw);
           } else {
             console.error('ERROR: Value referenced in mapping but none exist on this element.');
           }
@@ -351,7 +352,12 @@ function writeToFhir(def, fhir, cw) {
             // find related field if available
             const field = def.fields.find(f => f.identifier.equals(fhirMappingToIdentifier(fieldMapPath[0])));
             if(field !== undefined){
-              generateFHIRAssignment(field.card.isList, baseIsList, element.path, classMethodChain, cw);
+              // console.log(field.identifier.name);
+              if (!alreadyMappedElements.has(classMethodChain)) {
+                const constraintsLength = field.constraintsFilter.includesType.constraints.length;
+                generateFHIRAssignment(field.card.isList, baseIsList, constraintsLength, element.path, classMethodChain, fhirProfile, cw);
+                alreadyMappedElements.set(classMethodChain, element.path);
+              }
             }
           }
         }
@@ -360,7 +366,7 @@ function writeToFhir(def, fhir, cw) {
   }
 
   // not a profile, check to see if it has an extension
-  if(!fhirProfile && fhirExtension){
+  if(fhirExtension){
     // When calling a method on an es6 instance that has a FHIR extension, you may either want to method to resolve directly to a value (e.g. 12)
     //   or you may want it to be represented as an extension if it is not mapped to an element in a FHIR resource, such as 
     //   [{url: 'http://extension, valueInteger: 12}]
@@ -444,7 +450,7 @@ function generateAssignmentIfList(card, jsonString, valueString, cw) {
 }
 
 // TODO: Refactor.  How to handle arrays in middle of mapping chains?
-function generateFHIRAssignment(card, baseCard, fhirElementPath, valueString, cw) {
+function generateFHIRAssignment(card, baseCard, constraintsLength, fhirElementPath, valueString, fhirProfile, cw) {
   const valueArray = valueString.split('.');
   let prev = 'this.' + valueArray.shift(); // start with this.firstInChain
   let check = `${prev} != null`; // e.g. this.firstInChain !== null && this.firstInChain.secondInChain !== null
@@ -453,18 +459,45 @@ function generateFHIRAssignment(card, baseCard, fhirElementPath, valueString, cw
     check = check + ' && ' + prev + ' != null';
   });
 
+  // If we have more things (as evidenced by the 'IncludesTypeConstraints' that we need to fit into the end of the path)
+  // than we can fit into it, then we need to figure out where the closest array to the current element is.
+  // This will get put into 'containerProfile' if it exists.
+  let containerProfileArray;
+  if (!(card || baseCard) && constraintsLength > 1) {
+    const pathArrayClone = fhirElementPath.split('.');
+    // loop over the pathArrayClone to figure out where th nearest 0..*-cardinality element is
+    while (pathArrayClone.length > 0) {
+      pathArrayClone.pop();
+      const searchString = pathArrayClone.join('.');
+      const candidateProfile = fhirProfile.snapshot.element.find(e => { return e.path === searchString; });
+      // If we find a profile that matches the search string, and which has a 'max' (cardinality) of *
+      // That's our nearest array element (into which we're going to put our elements)
+      if (candidateProfile && candidateProfile.max == '*') {
+        // containerProfileArray gives us the string array to the nearest array element
+        containerProfileArray = pathArrayClone.slice(1);
+        break;
+      }
+    }
+  }
+
   cw.bl(`if (${check})`, () => {
     const pathArray = fhirElementPath.split('.');
     pathArray.shift(); // discard the first because it is the resource name
     let pathString = '';  // pathstring contains inst['fhirFirstLevel']['fhirSecondLevel']
     const previous = [];
+    let containedPathArray;
     while(pathArray.length > 0){
       previous.push(pathArray.shift());
       pathString = previous.map(e => `['${e}']`).join(''); // build out the pathString
-      if(pathArray.length > 0){
+      if(pathArray.length > 0){        
         cw.bl(`if(inst${pathString} === undefined)`, () => {
-          // Should we handle array cases?
-          cw.ln(`inst${pathString} = {};`); // make sure the each level of the json is initialized first
+          // Handle cases where there's an array in the middle of the element chain
+          if (containerProfileArray && containerProfileArray.map(e => `['${e}']`).join('') == pathString) {
+            cw.ln(`inst${pathString} = [];`);
+            containedPathArray = pathArray.slice(0);
+          } else {
+            cw.ln(`inst${pathString} = {};`); // make sure the each level of the json is initialized first
+          }
         });
       }
     }
@@ -481,7 +514,27 @@ function generateFHIRAssignment(card, baseCard, fhirElementPath, valueString, cw
           cw.ln(`inst${pathString}.push(typeof this.${valueString}.toFHIR === 'function' ? this.${valueString}.toFHIR() : this.${valueString});`);
         }
       } else {
-        cw.ln(`inst${pathString} = typeof this.${valueString}.toFHIR === 'function' ? this.${valueString}.toFHIR() : this.${valueString};`);
+        // If we have to map our elements to an array higher up in the profile
+        if (containerProfileArray) {
+          // Iterate through each element at current level, and map it to the array element
+          cw.bl(`this.${valueString}.forEach( (elem) => `, () => {
+            cw.ln('let containerInst = {};');
+            let containedPathString = '';
+            // Iterate through each level between the array element and our current element, and make sure they're all initialized.
+            containedPathArray.forEach(e => {
+              containedPathString = containedPathString.concat(`['${e}']`);
+              cw.ln(`containerInst${containedPathString} = {};`);
+            });
+            // Set the contained element instance's data with the current 'elem' element
+            cw.ln(`containerInst${containedPathString} = typeof elem.toFHIR === 'function' ? elem.toFHIR() : elem;`);
+            // Push the contained element instance onto the higher-level array
+            cw.ln(`inst${containerProfileArray.map(e => `['${e}']`).join('')}.push(containerInst);`);
+          });
+          // Close the `this.${valueString}.forEach( (elem) => block's parenthesis
+          cw.ln(');');
+        } else {
+          cw.ln(`inst${pathString} = typeof this.${valueString}.toFHIR === 'function' ? this.${valueString}.toFHIR() : this.${valueString};`);
+        }
       }
     }
   });

--- a/lib/generateClass.js
+++ b/lib/generateClass.js
@@ -350,7 +350,7 @@ function writeToFhir(def, fhir, cw) {
             // Generate a chain if mapped multiple levels deep, such as myField1.subField2
             const classMethodChain = fieldMapPath.map(e => toSymbol(fhirMappingToIdentifier(e).name)).join('.');
             // find related field if available
-            const field = def.fields.find(f => f.identifier.equals(fhirMappingToIdentifier(fieldMapPath[0])));
+            const field = def.fields.find(f => f.identifier && f.identifier.equals(fhirMappingToIdentifier(fieldMapPath[0])));
             if(field !== undefined){
               // console.log(field.identifier.name);
               if (!alreadyMappedElements.has(classMethodChain)) {

--- a/lib/generateClass.js
+++ b/lib/generateClass.js
@@ -333,7 +333,7 @@ function writeToFhir(def, fhir, cw) {
 
     for (let element of fhirProfile.snapshot.element) {
       const mapping = element.mapping && element.mapping.find(m => m['identity'] === 'shr');
-      let baseIsList = element.base && element.base.max == '*' && element.max == '1';
+      let baseIsList = element.base && element.base.max == '*';
       baseIsList = baseIsList || (element.mapping && element.mapping.filter(elem => elem.identity == 'shr').length > 1);
       if(mapping !== undefined){
         if(mapping.map === '<Value>'){
@@ -449,8 +449,17 @@ function generateAssignmentIfList(card, jsonString, valueString, cw) {
   });
 }
 
-// TODO: Refactor.  How to handle arrays in middle of mapping chains?
-function generateFHIRAssignment(card, baseCard, constraintsLength, fhirElementPath, valueString, fhirProfile, cw) {
+/**
+ * Generates the "assignment" portion of the toFHIR method, where the SHR elements get built into the FHIR json
+ * @param {boolean} cardIsList whether the element cardinality is a "list" (aka > 1)
+ * @param {boolean} baseCardIsList whether the element is "based" on an element whose cardinality is a list (> 1)
+ * @param {Number} constraintsLength the number of constraints on the element; used to determine whether there are more contstrained elements than cardinalities
+ * @param {string} fhirElementPath the FHIR element that the data should be put into (in FQN notation)
+ * @param {string} valueString the SHR element that the data should be taken from (in FQN notation)
+ * @param {Object} fhirProfile the FHIR profile the element comes from
+ * @param {CodeWriter} cw the CodeWriter that is writing the file for this element
+ */
+function generateFHIRAssignment(cardIsList, baseCardIsList, constraintsLength, fhirElementPath, valueString, fhirProfile, cw) {
   const valueArray = valueString.split('.');
   let prev = 'this.' + valueArray.shift(); // start with this.firstInChain
   let check = `${prev} != null`; // e.g. this.firstInChain !== null && this.firstInChain.secondInChain !== null
@@ -463,16 +472,16 @@ function generateFHIRAssignment(card, baseCard, constraintsLength, fhirElementPa
   // than we can fit into it, then we need to figure out where the closest array to the current element is.
   // This will get put into 'containerProfile' if it exists.
   let containerProfileArray;
-  if (!(card || baseCard) && constraintsLength > 1) {
+  if (!(cardIsList || baseCardIsList) && constraintsLength > 1) {
     const pathArrayClone = fhirElementPath.split('.');
     // loop over the pathArrayClone to figure out where th nearest 0..*-cardinality element is
     while (pathArrayClone.length > 0) {
       pathArrayClone.pop();
       const searchString = pathArrayClone.join('.');
-      const candidateProfile = fhirProfile.snapshot.element.find(e => { return e.path === searchString; });
-      // If we find a profile that matches the search string, and which has a 'max' (cardinality) of *
+      const candidateSnapshotElement = fhirProfile.snapshot.element.find(e => { return e.path === searchString; });
+      // If we find a snapshot element that matches the search string, and which has a 'max' (cardinality) of *
       // That's our nearest array element (into which we're going to put our elements)
-      if (candidateProfile && candidateProfile.max == '*') {
+      if (candidateSnapshotElement && candidateSnapshotElement.max == '*') {
         // containerProfileArray gives us the string array to the nearest array element
         containerProfileArray = pathArrayClone.slice(1);
         break;
@@ -506,9 +515,9 @@ function generateFHIRAssignment(card, baseCard, constraintsLength, fhirElementPa
       cw.ln(`inst['extension'] = inst['extension'] || [];`);
       cw.ln(`inst['extension'].push(this.${valueString}.toFHIR(true));`);//typeof this.${valueString}.toFHIR === 'function' ? this.${valueString}.toFHIR(true) : this.${valueString});`);
     } else {
-      if (card || baseCard) {
+      if (cardIsList || baseCardIsList) {
         cw.ln(`inst${pathString} = inst ${pathString} || [];`);
-        if (card) {
+        if (cardIsList) {
           cw.ln(`inst${pathString}.concat(this.${valueString}.map(f => typeof f.toFHIR === 'function' ? f.toFHIR() : f));`);
         } else {
           cw.ln(`inst${pathString}.push(typeof this.${valueString}.toFHIR === 'function' ? this.${valueString}.toFHIR() : this.${valueString});`);

--- a/lib/generateClass.js
+++ b/lib/generateClass.js
@@ -513,12 +513,12 @@ function generateFHIRAssignment(cardIsList, baseCardIsList, constraintsLength, f
 
     if(fhirElementPath.split('.')[1] === 'extension'){
       cw.ln(`inst['extension'] = inst['extension'] || [];`);
-      cw.ln(`inst['extension'].push(this.${valueString}.toFHIR(true));`);//typeof this.${valueString}.toFHIR === 'function' ? this.${valueString}.toFHIR(true) : this.${valueString});`);
+      cw.ln(`inst['extension'].push(typeof this.${valueString}.toFHIR === 'function' ? this.${valueString}.toFHIR(true) : this.${valueString});`);
     } else {
       if (cardIsList || baseCardIsList) {
         cw.ln(`inst${pathString} = inst ${pathString} || [];`);
         if (cardIsList) {
-          cw.ln(`inst${pathString}.concat(this.${valueString}.map(f => typeof f.toFHIR === 'function' ? f.toFHIR() : f));`);
+          cw.ln(`inst${pathString} = inst${pathString}.concat(this.${valueString}.map(f => typeof f.toFHIR === 'function' ? f.toFHIR() : f));`);
         } else {
           cw.ln(`inst${pathString}.push(typeof this.${valueString}.toFHIR === 'function' ? this.${valueString}.toFHIR() : this.${valueString});`);
         }

--- a/lib/generateClass.js
+++ b/lib/generateClass.js
@@ -333,12 +333,12 @@ function writeToFhir(def, fhir, cw) {
 
     for (let element of fhirProfile.snapshot.element) {
       const mapping = element.mapping && element.mapping.find(m => m['identity'] === 'shr');
-
+      const baseIsList = element.base && element.base.max == '*' && element.max == '1';
       if(mapping !== undefined){
         if(mapping.map === '<Value>'){
           // Mapping to the value of this es6 instance
           if (def.value instanceof IdentifiableValue && def.value.identifier.isPrimitive) {
-            generateFHIRAssignment(def.value.card, element.path, 'value', cw);
+            generateFHIRAssignment(def.value.card.isList, baseIsList, element.path, 'value', cw);
           } else {
             console.error('ERROR: Value referenced in mapping but none exist on this element.');
           }
@@ -351,7 +351,7 @@ function writeToFhir(def, fhir, cw) {
             // find related field if available
             const field = def.fields.find(f => f.identifier.equals(fhirMappingToIdentifier(fieldMapPath[0])));
             if(field !== undefined){
-              generateFHIRAssignment(field.card, element.path, classMethodChain, cw);
+              generateFHIRAssignment(field.card.isList, baseIsList, element.path, classMethodChain, cw);
             }
           }
         }
@@ -362,7 +362,7 @@ function writeToFhir(def, fhir, cw) {
   // not a profile, check to see if it has an extension
   if(!fhirProfile && fhirExtension){
     // When calling a method on an es6 instance that has a FHIR extension, you may either want to method to resolve directly to a value (e.g. 12)
-    //   or you may want it to be represented as an extension if it is not mapped to an element in a FHRI resource, such as 
+    //   or you may want it to be represented as an extension if it is not mapped to an element in a FHIR resource, such as 
     //   [{url: 'http://extension, valueInteger: 12}]
     //   asExtension tells which way to export it depending where in the parent class this exists (extension or not)
     cw.bl(`if (asExtension)`, () => {
@@ -422,7 +422,7 @@ function fhirMappingToIdentifier(mappingString){
   const bareMappingString = mappingString.slice(1,-1); // remove <>
   const mappingStringArray = bareMappingString.split('.');
   const name = mappingStringArray.pop();
-  const namespace = mappingStringArray.join('.')
+  const namespace = mappingStringArray.join('.');
   return new Identifier(namespace, name);
 }
 
@@ -443,15 +443,14 @@ function generateAssignmentIfList(card, jsonString, valueString, cw) {
   });
 }
 
-
 // TODO: Refactor.  How to handle arrays in middle of mapping chains?
-function generateFHIRAssignment(card, fhirElementPath, valueString, cw) {
-  const valueArray = valueString.split('.')
+function generateFHIRAssignment(card, baseCard, fhirElementPath, valueString, cw) {
+  const valueArray = valueString.split('.');
   let prev = 'this.' + valueArray.shift(); // start with this.firstInChain
-  let check = `${prev} !== null`; // e.g. this.firstInChain !== null && this.firstInChain.secondInChain !== null
+  let check = `${prev} != null`; // e.g. this.firstInChain !== null && this.firstInChain.secondInChain !== null
   valueArray.forEach(v => {
     prev = prev + '.' + v;
-    check = check + ' && ' + prev + ' !== null';
+    check = check + ' && ' + prev + ' != null';
   });
 
   cw.bl(`if (${check})`, () => {
@@ -461,7 +460,7 @@ function generateFHIRAssignment(card, fhirElementPath, valueString, cw) {
     const previous = [];
     while(pathArray.length > 0){
       previous.push(pathArray.shift());
-      pathString = previous.map(e => `['${e}']`).join('') // build out the pathString
+      pathString = previous.map(e => `['${e}']`).join(''); // build out the pathString
       if(pathArray.length > 0){
         cw.bl(`if(inst${pathString} === undefined)`, () => {
           // Should we handle array cases?
@@ -474,8 +473,13 @@ function generateFHIRAssignment(card, fhirElementPath, valueString, cw) {
       cw.ln(`inst['extension'] = inst['extension'] || [];`);
       cw.ln(`inst['extension'].push(this.${valueString}.toFHIR(true));`);//typeof this.${valueString}.toFHIR === 'function' ? this.${valueString}.toFHIR(true) : this.${valueString});`);
     } else {
-      if (card.isList) {
-        cw.ln(`inst${pathString} = this.${valueString}.map(f => typeof f.toFHIR === 'function' ? f.toFHIR() : f);`);
+      if (card || baseCard) {
+        cw.ln(`inst${pathString} = inst ${pathString} || [];`);
+        if (card) {
+          cw.ln(`inst${pathString}.concat(this.${valueString}.map(f => typeof f.toFHIR === 'function' ? f.toFHIR() : f));`);
+        } else {
+          cw.ln(`inst${pathString}.push(typeof this.${valueString}.toFHIR === 'function' ? this.${valueString}.toFHIR() : this.${valueString});`);
+        }
       } else {
         cw.ln(`inst${pathString} = typeof this.${valueString}.toFHIR === 'function' ? this.${valueString}.toFHIR() : this.${valueString};`);
       }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "shr-models": "^5.5.2",
     "shr-test-helpers": "^5.1.3",
     "shr-text-import": "^5.4.0",
-    "shr-fhir-export": "^5.5.1"
+    "shr-fhir-export": "standardhealth/shr-fhir-export#to_fhir_slicing"
   },
   "peerDependencies": {
     "shr-models": "^5.2.2"

--- a/test/es6ToFHIRTest.js
+++ b/test/es6ToFHIRTest.js
@@ -44,7 +44,7 @@ describe('#ToFHIR', () => {
     });
   });
 
-  describe('#BloodPressure()', () => {
+  describe('#BloodPressureEntry()', () => {
     const BloodPressureEntry = importResult('shr/slicing/BloodPressureEntry');
     it('should serialize to a validated BloodPressureEntry instance', () => {
       const json = context.getJSON('BloodPressureEntry', false);
@@ -52,6 +52,17 @@ describe('#ToFHIR', () => {
       const fhir = entry.toFHIR();
       expect(fhir).is.a('object');
       context.validateFHIR('BloodPressureEntry', fhir);
+    });
+  });
+
+  describe('#BarAEntry()', () => {
+    const BarAEntry = importResult('shr/slicing/BarAEntry');
+    it('should serialize to a validated BarAEntry instance', () => {
+      const json = context.getJSON('BarAEntry', false);
+      const entry = BarAEntry.fromJSON(json);
+      const fhir = entry.toFHIR();
+      expect(fhir).is.a('object');
+      context.validateFHIR('BarAEntry', fhir);
     });
   });
 

--- a/test/es6ToFHIRTest.js
+++ b/test/es6ToFHIRTest.js
@@ -16,9 +16,10 @@ describe('#ToFHIR', () => {
     it('should serialize to a validated PatientDirectMapEntry instance', () => {
       const json = context.getJSON('PatientDirectMapEntry', false);
       const entry = PatientDirectMapEntry.fromJSON(json);
-      const fhir = entry.toFHIR();
-      expect(fhir).is.a('object');
-      context.validateFHIR('PatientDirectMapEntry', fhir);
+      const gen_fhir = entry.toFHIR();
+      expect(gen_fhir).is.a('object');
+      const fhir = context.getFHIR('PatientDirectMapEntry');
+      expect(gen_fhir).to.eql(fhir);
     });
   });
   
@@ -27,9 +28,10 @@ describe('#ToFHIR', () => {
     it('should serialize to a validated PatientEntry instance', () => {
       const json = context.getJSON('PatientEntry', false);
       const entry = PatientEntry.fromJSON(json);
-      const fhir = entry.toFHIR();
-      expect(fhir).is.a('object');
-      context.validateFHIR('PatientEntry', fhir);
+      const gen_fhir = entry.toFHIR();
+      expect(gen_fhir).is.a('object');
+      const fhir = context.getFHIR('PatientEntry');
+      expect(gen_fhir).to.eql(fhir);
     });
   });
 
@@ -38,9 +40,10 @@ describe('#ToFHIR', () => {
     it('should serialize to a validated PractitionerEntry instance', () => {
       const json = context.getJSON('PractitionerEntry', false);
       const entry = PractitionerEntry.fromJSON(json);
-      const fhir = entry.toFHIR();
-      expect(fhir).is.a('object');
-      context.validateFHIR('PractitionerEntry', fhir);
+      const gen_fhir = entry.toFHIR();
+      expect(gen_fhir).is.a('object');
+      const fhir = context.getFHIR('PractitionerEntry');
+      expect(gen_fhir).to.eql(fhir);
     });
   });
 
@@ -49,9 +52,10 @@ describe('#ToFHIR', () => {
     it('should serialize to a validated BloodPressureEntry instance', () => {
       const json = context.getJSON('BloodPressureEntry', false);
       const entry = BloodPressureEntry.fromJSON(json);
-      const fhir = entry.toFHIR();
-      expect(fhir).is.a('object');
-      context.validateFHIR('BloodPressureEntry', fhir);
+      const gen_fhir = entry.toFHIR();
+      expect(gen_fhir).is.a('object');
+      const fhir = context.getFHIR('BloodPressureEntry');
+      expect(gen_fhir).to.eql(fhir);
     });
   });
 
@@ -60,9 +64,10 @@ describe('#ToFHIR', () => {
     it('should serialize to a validated BarAEntry instance', () => {
       const json = context.getJSON('BarAEntry', false);
       const entry = BarAEntry.fromJSON(json);
-      const fhir = entry.toFHIR();
-      expect(fhir).is.a('object');
-      context.validateFHIR('BarAEntry', fhir);
+      const gen_fhir = entry.toFHIR();
+      expect(gen_fhir).is.a('object');
+      const fhir = context.getFHIR('BarAEntry');
+      expect(gen_fhir).to.eql(fhir);
     });
   });
 

--- a/test/es6ToFHIRTest.js
+++ b/test/es6ToFHIRTest.js
@@ -44,4 +44,15 @@ describe('#ToFHIR', () => {
     });
   });
 
+  describe('#BloodPressure()', () => {
+    const BloodPressureEntry = importResult('shr/slicing/BloodPressureEntry');
+    it('should serialize to a validated BloodPressureEntry instance', () => {
+      const json = context.getJSON('BloodPressureEntry', false);
+      const entry = BloodPressureEntry.fromJSON(json);
+      const fhir = entry.toFHIR();
+      expect(fhir).is.a('object');
+      context.validateFHIR('BloodPressureEntry', fhir);
+    });
+  });
+
 });

--- a/test/fixtures/fhir-schema/BarAEntry.fhir.schema.json
+++ b/test/fixtures/fhir-schema/BarAEntry.fhir.schema.json
@@ -18,28 +18,64 @@
           "uniqueItems": true,
           "items": {
             "type": "object",
-            "properties": {
-              "target": {
-                "type": "object",
+            "oneOf":[
+              {
+                "description": "One possible element in the 'related' array",
                 "properties": {
-                  "_ShrId": {
-                    "type": "string"
-                  },
-                  "_EntryId": {
-                    "type": "string"
-                  },
-                  "_entryType": {
+                  "target": {
                     "type": "object",
                     "properties": {
-                      "value": {
-                        "type": "string"
+                      "shrId": {
+                        "type": "string",
+                        "const": "4-1"
+                      },
+                      "entryId": {
+                        "type": "string",
+                        "const": "4"
+                      },
+                      "entryType": {
+                        "type": "object",
+                        "properties": {
+                          "Value": {
+                            "type": "string",
+                            "const": "http://standardhealthrecord.org/spec/shr/slicing/FooA"
+                          }
+                        }
                       }
-                    }
+                    },
+                    "required": ["shrId", "entryId", "entryType"]
+                  }
+                }
+              },
+              {
+                "description": "One possible element in the 'related' array",
+                "properties": {
+                  "target": {
+                    "type": "object",
+                    "properties": {
+                      "shrId": {
+                        "type": "string",
+                        "const": "5-1"
+                      },
+                      "entryId": {
+                        "type": "string",
+                        "const": "5"
+                      },
+                      "entryType": {
+                        "type": "object",
+                        "properties": {
+                          "Value": {
+                            "type": "string",
+                            "const": "http://standardhealthrecord.org/spec/shr/slicing/FooB"
+                          }
+                        }
+                      }
+                    },
+                    "required": ["shrId", "entryId", "entryType"]
                   }
                 }
               }
-            }
-            
+            ]
           }
         }
       },

--- a/test/fixtures/fhir-schema/BarAEntry.fhir.schema.json
+++ b/test/fixtures/fhir-schema/BarAEntry.fhir.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://standardhealth.org/fhir/json-schema/BarAEntry",
+  "$ref": "#/definitions/BarAEntry",
+  "definitions": {
+    "BarAEntry": {
+      "description": "A simple entry that constrains a FHIR resource",
+      "properties": {
+        "resourceType": {
+          "description": "Observation resource type",
+          "type": "string",
+          "enum": ["Observation"]
+        },
+        "related": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "properties": {
+              "target": {
+                "type": "object",
+                "properties": {
+                  "_ShrId": {
+                    "type": "string"
+                  },
+                  "_EntryId": {
+                    "type": "string"
+                  },
+                  "_entryType": {
+                    "type": "object",
+                    "properties": {
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            
+          }
+        }
+      },
+      "required": ["resourceType", "related"]
+    }
+  }
+}

--- a/test/fixtures/fhir-schema/BloodPressureEntry.fhir.schema.json
+++ b/test/fixtures/fhir-schema/BloodPressureEntry.fhir.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "http://standardhealth.org/fhir/json-schema/BloodPressureEntry",
+  "$ref": "#/definitions/BloodPressureEntry",
+  "definitions": {
+    "BloodPressureEntry": {
+      "description": "A simple entry that constrains a FHIR resource",
+      "properties": {
+        "resourceType": {
+          "description": "Observation resource type",
+          "type": "string",
+          "enum": ["Observation"]
+        },
+        "component": {
+          "type": "array",
+          "items": [
+            {
+              "type": "string",
+              "enum": ["Systolic", "Diastolic"]
+            }
+          ],
+          "minItems": 2,
+          "maxItems": 2,
+          "uniqueItems": true
+        }
+      },
+      "required": ["resourceType", "component"]
+    }
+  }
+}

--- a/test/fixtures/fhir/BarAEntry.json
+++ b/test/fixtures/fhir/BarAEntry.json
@@ -1,0 +1,17 @@
+{
+  "resourceType": "Observation",
+  "id": "1-1",
+  "meta": {
+    "profile": [
+      "http://es6-export.com/fhir/StructureDefinition/shr-slicing-BarAEntry"
+    ]
+  },
+  "related": [
+    {
+      "target": "4"
+    },
+    {
+      "target": "5"
+    }
+  ]
+}

--- a/test/fixtures/fhir/BloodPressureEntry.json
+++ b/test/fixtures/fhir/BloodPressureEntry.json
@@ -1,0 +1,17 @@
+{
+  "resourceType": "Observation",
+  "id": "1-1",
+  "meta": {
+    "profile": [
+      "http://es6-export.com/fhir/StructureDefinition/shr-slicing-BloodPressureEntry"
+    ]
+  },
+  "component": [
+    {
+      "code": "Systolic"
+    },
+    {
+      "code": "Diastolic"
+    }
+  ]
+}

--- a/test/fixtures/fhir/PatientDirectMapEntry.json
+++ b/test/fixtures/fhir/PatientDirectMapEntry.json
@@ -1,0 +1,10 @@
+{
+  "resourceType": "Patient",
+  "id": "1-1",
+  "meta": {
+    "profile": [
+      "http://es6-export.com/fhir/StructureDefinition/shr-fhir-PatientDirectMapEntry"
+    ]
+  },
+  "active": true
+}

--- a/test/fixtures/fhir/PatientEntry.json
+++ b/test/fixtures/fhir/PatientEntry.json
@@ -1,0 +1,43 @@
+{
+  "resourceType": "Patient",
+  "id": "1-1",
+  "meta": {
+    "profile": [
+      "http://es6-export.com/fhir/StructureDefinition/shr-fhir-PatientEntry"
+    ]
+  },
+  "extension": [
+    {
+      "url": "http://es6-export.com/fhir/StructureDefinition/shr-simple-IntegerValueElement-extension",
+      "valueInteger": 19
+    },
+    {
+      "url": "http://es6-export.com/fhir/StructureDefinition/shr-simple-DecimalValueElement-extension",
+      "valueDecimal": 12.1
+    },
+    {
+      "extension": [
+        {
+          "url": "http://es6-export.com/fhir/StructureDefinition/shr-simple-StringValue-extension",
+          "valueString": "MyString"
+        },
+        {
+          "url": "http://es6-export.com/fhir/StructureDefinition/shr-simple-BooleanValue-extension",
+          "valueBoolean": true
+        }
+      ],
+      "url": "http://es6-export.com/fhir/StructureDefinition/shr-fhir-ComplexExtension-extension"
+    }
+  ],
+  "active": true,
+  "name": {
+    "text": "MyString"
+  },
+  "birthDate": "2017-12-05",
+  "deceasedBoolean": true,
+  "photo": [
+    {
+      "title": "Photo Note"
+    }
+  ]
+}

--- a/test/fixtures/fhir/PractitionerEntry.json
+++ b/test/fixtures/fhir/PractitionerEntry.json
@@ -1,0 +1,13 @@
+{
+  "resourceType": "Practitioner",
+  "id": "1-1",
+  "meta": {
+    "profile": [
+      "http://es6-export.com/fhir/StructureDefinition/shr-fhir-PractitionerEntry"
+    ]
+  },
+  "active": true,
+  "name": {
+    "text": "Rob"
+  }
+}

--- a/test/fixtures/instances/BarAEntry.json
+++ b/test/fixtures/instances/BarAEntry.json
@@ -1,0 +1,50 @@
+{
+  "EntryId": {
+    "EntryType": {
+      "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"
+    },
+    "Value": "1-1"
+  },
+  "ShrId": {
+    "EntryType": {
+      "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"
+    },
+    "Value": "1"
+  },
+  "CreationTime": {
+    "EntryType": {
+      "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+    },
+    "Value": "2018-08-06T12:34:56Z"
+  },
+  "LastUpdated": {
+    "EntryType": {
+      "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+    },
+    "Value": "2018-08-06T12:34:56Z"
+  },
+  "EntryType": {
+    "Value": "http://standardhealthrecord.org/spec/shr/fhir/BarAEntry"
+  },
+  "Baz": {
+    "EntryType": {
+      "Value": "http://standardhealthrecord.org/spec/shr/slicing/Baz"
+    },
+    "Foo": [
+      {
+        "_ShrId": "4-1",
+        "_EntryId": "4",
+        "_EntryType": {
+          "Value": "http://standardhealthrecord.org/spec/shr/slicing/FooA"
+        }
+      },
+      {
+        "_ShrId": "5-1",
+        "_EntryId": "5",
+        "_EntryType": {
+          "Value": "http://standardhealthrecord.org/spec/shr/slicing/FooB"
+        }
+      }
+    ]
+  }
+}

--- a/test/fixtures/instances/BloodPressureEntry.json
+++ b/test/fixtures/instances/BloodPressureEntry.json
@@ -1,0 +1,41 @@
+{
+  "shr.base.EntryId": {
+    "shr.base.EntryType": {
+      "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"
+    },
+    "Value": "1-1"
+  },
+  "shr.base.ShrId": {
+    "shr.base.EntryType": {
+      "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"
+    },
+    "Value": "1"
+  },
+  "shr.core.CreationTime": {
+    "shr.base.EntryType": {
+      "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
+    },
+    "Value": "2018-08-06T12:34:56Z"
+  },
+  "shr.base.LastUpdated": {
+    "shr.base.EntryType": {
+      "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
+    },
+    "Value": "2018-08-06T12:34:56Z"
+  },
+  "shr.base.EntryType": {
+    "Value": "http://standardhealthrecord.org/spec/shr/fhir/BloodPressureEntry"
+  },
+  "shr.slicing.SystolicPressure": {
+    "shr.base.EntryType": {
+      "Value": "http://standardhealthrecord.org/spec/shr/slicing/SystolicPressure"
+    },
+    "Value": "Systolic"
+  },
+  "shr.slicing.DiastolicPressure": {
+    "shr.base.EntryType": {
+      "Value": "http://standardhealthrecord.org/spec/shr/slicing/DiastolicPressure"
+    },
+    "Value": "Diastolic"
+  }
+}

--- a/test/fixtures/instances/BloodPressureEntry.json
+++ b/test/fixtures/instances/BloodPressureEntry.json
@@ -1,39 +1,39 @@
 {
-  "shr.base.EntryId": {
-    "shr.base.EntryType": {
+  "EntryId": {
+    "EntryType": {
       "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"
     },
     "Value": "1-1"
   },
-  "shr.base.ShrId": {
-    "shr.base.EntryType": {
+  "ShrId": {
+    "EntryType": {
       "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"
     },
     "Value": "1"
   },
-  "shr.core.CreationTime": {
-    "shr.base.EntryType": {
+  "CreationTime": {
+    "EntryType": {
       "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"
     },
     "Value": "2018-08-06T12:34:56Z"
   },
-  "shr.base.LastUpdated": {
-    "shr.base.EntryType": {
+  "LastUpdated": {
+    "EntryType": {
       "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"
     },
     "Value": "2018-08-06T12:34:56Z"
   },
-  "shr.base.EntryType": {
+  "EntryType": {
     "Value": "http://standardhealthrecord.org/spec/shr/fhir/BloodPressureEntry"
   },
-  "shr.slicing.SystolicPressure": {
-    "shr.base.EntryType": {
+  "SystolicPressure": {
+    "EntryType": {
       "Value": "http://standardhealthrecord.org/spec/shr/slicing/SystolicPressure"
     },
     "Value": "Systolic"
   },
-  "shr.slicing.DiastolicPressure": {
-    "shr.base.EntryType": {
+  "DiastolicPressure": {
+    "EntryType": {
       "Value": "http://standardhealthrecord.org/spec/shr/slicing/DiastolicPressure"
     },
     "Value": "Diastolic"

--- a/test/fixtures/spec/shr_slicing.txt
+++ b/test/fixtures/spec/shr_slicing.txt
@@ -1,0 +1,52 @@
+Grammar:    DataElement 5.0
+Namespace:  shr.slicing
+Uses: shr.simple
+
+Element: BP
+0..1 SystolicPressure
+0..1 DiastolicPressure
+
+Element:		SystolicPressure
+Based on: EvaluationComponent
+Concept:		LNC#8480-6
+Value:			string
+
+Element:		DiastolicPressure
+Based on: EvaluationComponent
+Concept:		LNC#8462-4
+Value:			string
+
+Element: EvaluationComponent
+Value: string
+
+Element: 		Observation
+0..1			PersonOfRecord
+0..1			SubjectIfNotPersonOfRecord
+0..1			AnyPersonOrOrganization
+0..1			Recorded
+0..1			Signed  // Author
+1..1			ObservationTopic
+1..1			ObservationContext
+
+Element: Foo
+Based on: Observation
+
+Element: FooA
+Based on: Foo
+
+Element: FooB
+Based on: Foo
+
+EntryElement: Bar
+Based on: Observation
+0..1 Baz
+
+EntryElement: BarA
+Based on: Bar
+Baz.Foo
+  includes 0..1 FooA
+  includes 0..1 FooB
+
+Element: Baz
+0..* ref(Foo)
+

--- a/test/fixtures/spec/shr_slicing.txt
+++ b/test/fixtures/spec/shr_slicing.txt
@@ -2,7 +2,7 @@ Grammar:    DataElement 5.0
 Namespace:  shr.slicing
 Uses: shr.simple
 
-Element: BP
+EntryElement: BloodPressureEntry
 0..1 SystolicPressure
 0..1 DiastolicPressure
 

--- a/test/fixtures/spec/shr_slicing.txt
+++ b/test/fixtures/spec/shr_slicing.txt
@@ -19,7 +19,7 @@ Value:			string
 Element: EvaluationComponent
 Value: string
 
-Element: 		Observation
+EntryElement: 		Observation
 0..1			PersonOfRecord
 0..1			SubjectIfNotPersonOfRecord
 0..1			AnyPersonOrOrganization
@@ -37,16 +37,15 @@ Based on: Foo
 Element: FooB
 Based on: Foo
 
-EntryElement: Bar
+Element: Bar
 Based on: Observation
 0..1 Baz
 
-EntryElement: BarA
+EntryElement: BarAEntry
 Based on: Bar
 Baz.Foo
-  includes 0..1 FooA
-  includes 0..1 FooB
+  includes 0..1 ref(FooA)
+  includes 0..1 ref(FooB)
 
 Element: Baz
 0..* ref(Foo)
-

--- a/test/fixtures/spec/shr_slicing_map.txt
+++ b/test/fixtures/spec/shr_slicing_map.txt
@@ -1,0 +1,14 @@
+Grammar:	Map 5.1
+Namespace:	shr.slicing
+Target:		FHIR_STU_3
+
+Observation maps to http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults:
+
+BarA:
+Baz.Foo maps to related.target (slice at = related; slice on = target.reference.resolve(); slice strategy = includes; slice on type = profile)
+
+BP maps to http://hl7.org/fhir/StructureDefinition/bp:
+SystolicPressure maps to component (slice # = 1)
+SystolicPressure.Value maps to component.code
+DiastolicPressure maps to component (slice # = 2)
+DiastolicPressure.Value maps to component.code

--- a/test/fixtures/spec/shr_slicing_map.txt
+++ b/test/fixtures/spec/shr_slicing_map.txt
@@ -7,7 +7,7 @@ Observation maps to http://hl7.org/fhir/us/core/StructureDefinition/us-core-obse
 BarA:
 Baz.Foo maps to related.target (slice at = related; slice on = target.reference.resolve(); slice strategy = includes; slice on type = profile)
 
-BP maps to http://hl7.org/fhir/StructureDefinition/bp:
+BloodPressureEntry maps to http://hl7.org/fhir/StructureDefinition/bp:
 SystolicPressure maps to component (slice # = 1)
 SystolicPressure.Value maps to component.code
 DiastolicPressure maps to component (slice # = 2)

--- a/test/fixtures/spec/shr_slicing_map.txt
+++ b/test/fixtures/spec/shr_slicing_map.txt
@@ -4,8 +4,8 @@ Target:		FHIR_STU_3
 
 Observation maps to http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults:
 
-BarA:
-Baz.Foo maps to related.target (slice at = related; slice on = target.reference.resolve(); slice strategy = includes; slice on type = profile)
+BarAEntry:
+Baz.Foo maps to related.target (slice at = related; slice on = reference.resolve(); slice strategy = includes; slice on type = profile)
 
 BloodPressureEntry maps to http://hl7.org/fhir/StructureDefinition/bp:
 SystolicPressure maps to component (slice # = 1)

--- a/yarn.lock
+++ b/yarn.lock
@@ -1415,9 +1415,9 @@ shr-expand@^5.5.1:
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.5.1.tgz#e8d3c0cebe9bf05d663f2e90d7ff439b39f1a82c"
 
-shr-fhir-export@^5.5.1:
+shr-fhir-export@standardhealth/shr-fhir-export#to_fhir_slicing:
   version "5.6.1"
-  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.6.1.tgz#acb6380380d7b626c7d8b73cd8358d035fcc6e98"
+  resolved "https://codeload.github.com/standardhealth/shr-fhir-export/tar.gz/0fbc8047777b783c63ef85a93c82830f1f5badc0"
   dependencies:
     fs-extra "^2.0.0"
     lodash "^4.17.5"


### PR DESCRIPTION
This PR adds support for two different types of "slicing" in SHR to the toFHIR exporter. 

1) Slicing where two fields on an `Entry` map to the same list field in a FHIR element. This is represented by the `BloodPressureEntry` Entry and the `SystolicPressure`/`DiastolicPressure` fields.

2) Slicing where one list field on an `Entry` maps to a list field in a FHIR element, but the types that are included in the list on the SHR side are constrained. This is represented by the `BarAEntry` Entry and the `FooA` and `FooB` type restrictions on the `Baz.foo` list.