### PR TITLE
Sep ballot fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,13 +28,13 @@
     "eslint": "^4.15.0",
     "fs-extra": "^4.0.2",
     "mocha": "^3.2.0",
-    "shr-expand": "^5.5.1",
-    "shr-json-schema-export": "^5.3.0",
-    "shr-models": "^5.5.2",
-    "shr-test-helpers": "^5.1.3",
-    "shr-text-import": "^5.4.0"
+    "shr-expand": "^5.5.2",
+    "shr-json-schema-export": "^5.3.1",
+    "shr-models": "^5.5.3",
+    "shr-test-helpers": "^5.2.2",
+    "shr-text-import": "^5.4.2"
   },
   "peerDependencies": {
-    "shr-models": "^5.2.2"
+    "shr-models": "^5.5.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-es6-export",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "description": "Exports ES6 classes represent SHR data elements",
   "author": "",
   "license": "Apache-2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1394,27 +1394,27 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-shr-expand@^5.5.1:
-  version "5.5.1"
-  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.5.1.tgz#e8d3c0cebe9bf05d663f2e90d7ff439b39f1a82c"
-
-shr-json-schema-export@^5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/shr-json-schema-export/-/shr-json-schema-export-5.3.0.tgz#2b1f1dd918381c23b4ebbca9946c0dc85dc227ce"
-
-shr-models@^5.5.2:
+shr-expand@^5.5.2:
   version "5.5.2"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.5.2.tgz#8871fa8626278a53dc729fc04512aaf2acf91b94"
+  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.5.2.tgz#e325327b8e1a1995229c7abb1fbef4a5347b67ff"
 
-shr-test-helpers@^5.1.3:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/shr-test-helpers/-/shr-test-helpers-5.2.0.tgz#8bb0982c53b1ce7d4e792bdf1cf73d94bde650f8"
+shr-json-schema-export@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/shr-json-schema-export/-/shr-json-schema-export-5.3.1.tgz#6eb8201a6c4911292db7aa15354d0ddaad902eee"
+
+shr-models@^5.5.3:
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.5.3.tgz#bc972ba2355bd7dd35d1169c7f17332967165c65"
+
+shr-test-helpers@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/shr-test-helpers/-/shr-test-helpers-5.2.2.tgz#31c18d3db71a0181cd18e74105b42881756f5834"
   dependencies:
     fs-extra "^5.0.0"
 
-shr-text-import@^5.4.0:
-  version "5.4.0"
-  resolved "https://registry.yarnpkg.com/shr-text-import/-/shr-text-import-5.4.0.tgz#9b131b279e2af6aad61709b13ea0f2286a229487"
+shr-text-import@^5.4.2:
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/shr-text-import/-/shr-text-import-5.4.2.tgz#4ee003bf50af1655a3bc6552aaa41e9612fba572"
   dependencies:
     antlr4 "~4.6.0"
 


### PR DESCRIPTION
- Upgrade: shr-models@^5.5.3, shr-text-import@^5.4.2, shr-expand@^5.5.2, shr-json-schema-export@^5.3.1, shr-test-helpers@^5.2.2
- Bump version number