### PR TITLE
Additional to_fhir informational exports 

### DIFF
--- a/lib/generateClass.js
+++ b/lib/generateClass.js
@@ -298,12 +298,17 @@ function writeToFhir(def, fhir, cw) {
   const alreadyMappedElements = new Map;
 
   cw.ln(`let inst = {};`);
+  cw.ln();
 
   if(fhirProfile !== undefined){
     // FHIR profile exists, so we will pull out the mapping information from element maps
 
     if(def.isEntry){
+      cw.ln('// Export entry-related elements to the FHIR JSON');
       cw.ln(`inst['resourceType'] = '${fhirProfile.type}';`);
+      cw.ln(`inst['id'] = this.entryInfo.entryId.value;`);
+      cw.ln(`inst['meta'] = { 'profile': ['${fhirProfile.url}'] };`);
+      cw.ln();
     }
 
     /* UNCOMMENT BELOW CODE TO JAM IN DUMMY MAPPING DATA */ 
@@ -331,6 +336,7 @@ function writeToFhir(def, fhir, cw) {
     //   // addMapping('Attachment.title', {'identity': 'shr', 'map': '<Value>'}); // DONE
     // }
 
+    cw.ln('// Export value and field elements (if any)');
     for (let element of fhirProfile.snapshot.element) {
       const mapping = element.mapping && element.mapping.find(m => m['identity'] === 'shr');
       let baseIsList = element.base && element.base.max == '*';

--- a/lib/generateClass.js
+++ b/lib/generateClass.js
@@ -306,7 +306,9 @@ function writeToFhir(def, fhir, cw) {
     if(def.isEntry){
       cw.ln('// Export entry-related elements to the FHIR JSON');
       cw.ln(`inst['resourceType'] = '${fhirProfile.type}';`);
-      cw.ln(`inst['id'] = this.entryInfo.entryId.value;`);
+      cw.bl('if (!!this.entryInfo && !!this.entryInfo.entryId)', () => {
+        cw.ln(`inst['id'] = this.entryInfo.entryId.value;`);
+      });
       cw.ln();
     }
 

--- a/lib/generateClass.js
+++ b/lib/generateClass.js
@@ -307,9 +307,10 @@ function writeToFhir(def, fhir, cw) {
       cw.ln('// Export entry-related elements to the FHIR JSON');
       cw.ln(`inst['resourceType'] = '${fhirProfile.type}';`);
       cw.ln(`inst['id'] = this.entryInfo.entryId.value;`);
-      cw.ln(`inst['meta'] = { 'profile': ['${fhirProfile.url}'] };`);
       cw.ln();
     }
+
+    cw.ln(`inst['meta'] = { 'profile': ['${fhirProfile.url}'] };`);
 
     /* UNCOMMENT BELOW CODE TO JAM IN DUMMY MAPPING DATA */ 
 

--- a/test/fixtures/fhir-schema/BarAEntry.fhir.schema.json
+++ b/test/fixtures/fhir-schema/BarAEntry.fhir.schema.json
@@ -77,9 +77,14 @@
               }
             ]
           }
+        },
+        "id": {
+          "description": "ID of the FHIR object instance",
+          "type": "string",
+          "value": "1-1"
         }
       },
-      "required": ["resourceType", "related"]
+      "required": ["resourceType", "related", "id"]
     }
   }
 }

--- a/test/fixtures/fhir-schema/BloodPressureEntry.fhir.schema.json
+++ b/test/fixtures/fhir-schema/BloodPressureEntry.fhir.schema.json
@@ -22,9 +22,14 @@
           "minItems": 2,
           "maxItems": 2,
           "uniqueItems": true
+        },
+        "id": {
+          "description": "ID of the FHIR object instance",
+          "type": "string",
+          "value": "1-1"
         }
       },
-      "required": ["resourceType", "component"]
+      "required": ["resourceType", "component", "id"]
     }
   }
 }

--- a/test/fixtures/fhir-schema/PatientDirectMapEntry.fhir.schema.json
+++ b/test/fixtures/fhir-schema/PatientDirectMapEntry.fhir.schema.json
@@ -15,9 +15,14 @@
           "description": "Active bit",
           "type": "boolean",
           "enum": [true]
+        },
+        "id": {
+          "description": "ID of the FHIR object instance",
+          "type": "string",
+          "value": "1-1"
         }
       },
-      "required": ["resourceType", "active"]
+      "required": ["resourceType", "active", "id"]
     }
   }
 }

--- a/test/fixtures/fhir-schema/PatientEntry.fhir.schema.json
+++ b/test/fixtures/fhir-schema/PatientEntry.fhir.schema.json
@@ -133,9 +133,14 @@
           "minItems": 3,
           "maxItems": 3,
           "additionalItems": false
+        },
+        "id": {
+          "description": "ID of the FHIR object instance",
+          "type": "string",
+          "value": "1-1"
         }
       },
-      "required": ["resourceType", "active", "birthDate", "name", "deceasedBoolean","extension"]
+      "required": ["resourceType", "active", "birthDate", "name", "deceasedBoolean", "extension", "id"]
     }
   }
 }

--- a/test/fixtures/fhir-schema/PractitionerEntry.fhir.schema.json
+++ b/test/fixtures/fhir-schema/PractitionerEntry.fhir.schema.json
@@ -25,9 +25,14 @@
             }
           },
           "required": ["text"]
+        },
+        "id": {
+          "description": "ID of the FHIR object instance",
+          "type": "string",
+          "value": "1-1"
         }
       },
-      "required": ["resourceType", "active", "name"]
+      "required": ["resourceType", "active", "name", "id"]
     }
   }
 }


### PR DESCRIPTION
NOTE: to be merged after `to_fhir_slicing`

This PR adds in some additional "informational" data to the JSON exported by `toFHIR()`:

* For entries, it adds an ID (as pulled from `entryId` on the object) when exporting
* For all objects, it adds a `meta` field with the profile the object is being exported for