### PR TITLE
Rename BarAEntry to PanelSliceByProfile

### DIFF
--- a/test/es6FromFHIRJSONTest.js
+++ b/test/es6FromFHIRJSONTest.js
@@ -222,37 +222,37 @@ describe('#FromFHIR', () => {
     });
   });
 
-  describe('#BarAEntry()', () => {
-    const BarAEntry = importResult('shr/slicing/BarAEntry');
-    const Baz = importResult('shr/slicing/Baz');
+  describe('#PanelSliceByProfile()', () => {
+    const PanelSliceByProfile = importResult('shr/slicing/PanelSliceByProfile');
+    const PanelMembers = importResult('shr/slicing/PanelMembers');
     const Reference = importResult('Reference');
     const ShrId = importResult('shr/base/ShrId');
     const EntryId = importResult('shr/base/EntryId');
     const EntryType = importResult('shr/base/EntryType');
     it('should deserialize a FHIR JSON instance', () => {
-      const json = context.getFHIR('BarAEntry');
-      const entry = BarAEntry.fromFHIR(json);
-      expect(entry).instanceOf(BarAEntry);
+      const json = context.getFHIR('PanelSliceByProfile');
+      const entry = PanelSliceByProfile.fromFHIR(json);
+      expect(entry).instanceOf(PanelSliceByProfile);
 
-      const expected = new BarAEntry()
-        .withBaz(new Baz()
-          .withFoo([
+      const expected = new PanelSliceByProfile()
+        .withPanelMembers(new PanelMembers()
+          .withObservation([
             new Reference(
               new ShrId().withValue('1-1'),
               new EntryId().withValue('4'),
-              new EntryType().withValue('http://standardhealthrecord.org/spec/shr/slicing/FooA')
+              new EntryType().withValue('http://standardhealthrecord.org/spec/shr/slicing/MemberA')
             ),
             new Reference(
               new ShrId().withValue('1-1'),
               new EntryId().withValue('5'),
-              new EntryType().withValue('http://standardhealthrecord.org/spec/shr/slicing/FooB')
+              new EntryType().withValue('http://standardhealthrecord.org/spec/shr/slicing/MemberB')
             )
           ])
         );
-      fixExpectedEntryInfo(expected, 'http://standardhealthrecord.org/spec/shr/slicing/BarAEntry', entry);
+      fixExpectedEntryInfo(expected, 'http://standardhealthrecord.org/spec/shr/slicing/PanelSliceByProfile', entry);
       // fix the expected references to use the same shrId and the overall expected shrID
-      expected.baz.foo[0].shrId = expected.entryInfo.shrId;
-      expected.baz.foo[1].shrId = expected.entryInfo.shrId;
+      expected.panelMembers.observation[0].shrId = expected.entryInfo.shrId;
+      expected.panelMembers.observation[1].shrId = expected.entryInfo.shrId;
 
       expect(entry).to.eql(expected);
     });

--- a/test/es6ToFHIRTest.js
+++ b/test/es6ToFHIRTest.js
@@ -59,14 +59,14 @@ describe('#ToFHIR', () => {
     });
   });
 
-  describe('#BarAEntry()', () => {
-    const BarAEntry = importResult('shr/slicing/BarAEntry');
-    it('should serialize to a validated BarAEntry instance', () => {
-      const json = context.getJSON('BarAEntry', false);
-      const entry = BarAEntry.fromJSON(json);
+  describe('#PanelSliceByProfile()', () => {
+    const PanelSliceByProfile = importResult('shr/slicing/PanelSliceByProfile');
+    it('should serialize to a validated PanelSliceByProfile instance', () => {
+      const json = context.getJSON('PanelSliceByProfile', false);
+      const entry = PanelSliceByProfile.fromJSON(json);
       const gen_fhir = entry.toFHIR();
       expect(gen_fhir).is.a('object');
-      const fhir = context.getFHIR('BarAEntry');
+      const fhir = context.getFHIR('PanelSliceByProfile');
       expect(gen_fhir).to.eql(fhir);
     });
   });

--- a/test/fixtures/fhir/PanelSliceByProfile.json
+++ b/test/fixtures/fhir/PanelSliceByProfile.json
@@ -3,7 +3,7 @@
   "id": "1-1",
   "meta": {
     "profile": [
-      "http://es6-export.com/fhir/StructureDefinition/shr-slicing-BarAEntry"
+      "http://es6-export.com/fhir/StructureDefinition/shr-slicing-PanelSliceByProfile"
     ]
   },
   "related": [

--- a/test/fixtures/instances/PanelSliceByProfile.json
+++ b/test/fixtures/instances/PanelSliceByProfile.json
@@ -24,25 +24,25 @@
     "Value": "2018-08-06T12:34:56Z"
   },
   "EntryType": {
-    "Value": "http://standardhealthrecord.org/spec/shr/fhir/BarAEntry"
+    "Value": "http://standardhealthrecord.org/spec/shr/fhir/PanelSliceByProfile"
   },
-  "Baz": {
+  "PanelMembers": {
     "EntryType": {
-      "Value": "http://standardhealthrecord.org/spec/shr/slicing/Baz"
+      "Value": "http://standardhealthrecord.org/spec/shr/slicing/PanelMembers"
     },
-    "Foo": [
+    "Observation": [
       {
         "_ShrId": "4-1",
         "_EntryId": "4",
         "_EntryType": {
-          "Value": "http://standardhealthrecord.org/spec/shr/slicing/FooA"
+          "Value": "http://standardhealthrecord.org/spec/shr/slicing/MemberA"
         }
       },
       {
         "_ShrId": "5-1",
         "_EntryId": "5",
         "_EntryType": {
-          "Value": "http://standardhealthrecord.org/spec/shr/slicing/FooB"
+          "Value": "http://standardhealthrecord.org/spec/shr/slicing/MemberB"
         }
       }
     ]

--- a/test/fixtures/spec/shr_slicing.txt
+++ b/test/fixtures/spec/shr_slicing.txt
@@ -38,24 +38,36 @@ EntryElement: 		Observation
 1..1			ObservationTopic
 1..1			ObservationContext
 
-Element: Foo
+// EntryElement: PanelSliceByProfile
+// Based on: Observation
+// 0..*      ref(Related)
+//   includes 0..1 ref(RelatedA)
+//   includes 0..1 ref(RelatedB)
+
+// EntryElement:  Related
+// Based on: Observation
+
+// EntryElement:  RelatedA
+// Based on: Related
+
+// EntryElement:  RelatedB
+// Based on: Related
+
+Element: MemberA
 Based on: Observation
 
-Element: FooA
-Based on: Foo
-
-Element: FooB
-Based on: Foo
-
-Element: Bar
+Element: MemberB
 Based on: Observation
-0..1 Baz
 
-EntryElement: BarAEntry
-Based on: Bar
-Baz.Foo
-  includes 0..1 ref(FooA)
-  includes 0..1 ref(FooB)
+Element: Panel
+Based on: Observation
+0..1 PanelMembers
 
-Element: Baz
-0..* ref(Foo)
+EntryElement: PanelSliceByProfile
+Based on: Panel
+PanelMembers.Observation
+  includes 0..1 ref(MemberA)
+  includes 0..1 ref(MemberB)
+
+Element: PanelMembers
+0..* ref(Observation)

--- a/test/fixtures/spec/shr_slicing_map.txt
+++ b/test/fixtures/spec/shr_slicing_map.txt
@@ -4,8 +4,8 @@ Target:		FHIR_STU_3
 
 Observation maps to http://hl7.org/fhir/us/core/StructureDefinition/us-core-observationresults:
 
-BarAEntry:
-Baz.Foo maps to related.target (slice at = related; slice on = reference.resolve(); slice strategy = includes; slice on type = profile)
+PanelSliceByProfile:
+PanelMembers.Observation maps to related.target (slice at = related; slice on = reference.resolve(); slice strategy = includes; slice on type = profile)
 
 BloodPressureSliceByNumber maps to http://hl7.org/fhir/StructureDefinition/bp:
 SystolicPressure maps to component (slice # = 1)
@@ -22,3 +22,6 @@ SystolicPressure.Value maps to component.value[x]
 DiastolicPressure maps to component
 DiastolicPressure.ComponentCode maps to component.code
 DiastolicPressure.Value maps to component.value[x]
+
+// PanelSliceByProfile maps to Observation:
+// Related maps to related.target (slice at = related; slice on = reference.resolve(); slice strategy = includes; slice on type = profile)


### PR DESCRIPTION
PanelSliceByProfile is based on the use case of a panel mapped to observation where panel members are related observations.