### PR TITLE
Support includes type paths

### DIFF
--- a/test/es6ClassTest.js
+++ b/test/es6ClassTest.js
@@ -7,7 +7,10 @@ require('babel-register')({
 describe('#Class', () => {
 
   let context;
-  before(() => context = setup('./test/fixtures/spec', 'config_stu3.json', './build/test', true));
+  before(function() {
+    this.timeout(5000);
+    context = setup('./test/fixtures/spec', 'config_stu3.json', './build/test', true);
+  });
 
   describe('#StringValueClass()', () => {
 

--- a/test/es6FactoryTest.js
+++ b/test/es6FactoryTest.js
@@ -7,7 +7,10 @@ require('babel-register')({
 describe('#Factory()', () => {
 
   let context;
-  before(() => context = setup('./test/fixtures/spec', 'config_stu3.json', './build/test', true));
+  before(function() {
+    this.timeout(5000);
+    context = setup('./test/fixtures/spec', 'config_stu3.json', './build/test', true);
+  });
 
   describe('#ObjectFactory()', () => {
 

--- a/test/es6FromFHIRJSONTest.js
+++ b/test/es6FromFHIRJSONTest.js
@@ -7,7 +7,8 @@ require('babel-register')({
 describe('#FromFHIR_STU3', () => {
 
   let context;
-  before(() => {
+  before(function() {
+    this.timeout(5000);
     context = setup('./test/fixtures/spec', 'config_stu3.json', './build/test', true);
     context.setupAjvJson('./build/test/schema');
     context.setupAjvFhir('./test/fixtures/fhir-schema', 'FHIR_STU_3');
@@ -342,7 +343,8 @@ describe('#FromFHIR_STU3', () => {
 describe('#FromFHIR_DSTU2', () => {
 
   let context;
-  before(() => {
+  before(function() {
+    this.timeout(5000);
     context = setup('./test/fixtures/spec', 'config_dstu2.json', './build/test_dstu2', true);
     context.setupAjvJson('./build/test/schema');
     context.setupAjvFhir('./test/fixtures/fhir-schema', 'FHIR_DSTU_2');

--- a/test/es6FromFHIRJSONTest.js
+++ b/test/es6FromFHIRJSONTest.js
@@ -250,6 +250,77 @@ describe('#FromFHIR_STU3', () => {
     });
   });
 
+  describe('#BloodPressureSliceByValueAndIncludesStrategy()', () => {
+
+    let BloodPressureSliceByValueAndIncludesStrategy, SystolicPressure, DiastolicPressure, ComponentCode, Quantity, Units, CodeableConcept, Coding, CodeSystem;
+    before(() => {
+      BloodPressureSliceByValueAndIncludesStrategy = context.importResult('shr/slicing/BloodPressureSliceByValueAndIncludesStrategy');
+      SystolicPressure = context.importResult('shr/slicing/SystolicPressure');
+      DiastolicPressure = context.importResult('shr/slicing/DiastolicPressure');
+      ComponentCode = context.importResult('shr/slicing/ComponentCode');
+      Quantity = context.importResult('shr/core/Quantity');
+      Units = context.importResult('shr/core/Units');
+      CodeableConcept = context.importResult('shr/core/CodeableConcept');
+      Coding = context.importResult('shr/core/Coding');
+      CodeSystem = context.importResult('shr/core/CodeSystem');
+    });
+
+    it('should deserialize a FHIR JSON instance', () => {
+      const json = context.getFHIR('BloodPressureSliceByValueAndIncludesStrategy');
+      const entry = BloodPressureSliceByValueAndIncludesStrategy.fromFHIR(json);
+      expect(entry).instanceOf(BloodPressureSliceByValueAndIncludesStrategy);
+
+      const expected = new BloodPressureSliceByValueAndIncludesStrategy()
+        .withEvaluationComponent([
+          new SystolicPressure()
+            .withValue(
+              new Quantity()
+                .withValue(120.0)
+                .withUnits(
+                  new Units().withCoding(
+                    new Coding()
+                      .withCodeSystem(new CodeSystem().withValue('http://unitsofmeasure.org'))
+                      .withCode('mm[Hg]')
+                  )
+                )
+            )
+            .withComponentCode(new ComponentCode()
+              .withValue(new CodeableConcept()
+                .withCoding([
+                  new Coding()
+                    .withCodeSystem(new CodeSystem().withValue('http://loinc.org'))
+                    .withCode('8480-6')
+                ])
+              )
+            ),
+          new DiastolicPressure()
+            .withValue(
+              new Quantity()
+                .withValue(80.0)
+                .withUnits(
+                  new Units().withCoding(
+                    new Coding()
+                      .withCodeSystem(new CodeSystem().withValue('http://unitsofmeasure.org'))
+                      .withCode('mm[Hg]')
+                  )
+                )
+            )
+            .withComponentCode(new ComponentCode()
+              .withValue(new CodeableConcept()
+                .withCoding([
+                  new Coding()
+                    .withCodeSystem(new CodeSystem().withValue('http://loinc.org'))
+                    .withCode('8462-4')
+                ])
+              )
+            )
+        ]);
+      fixExpectedEntryInfo(expected, 'http://standardhealthrecord.org/spec/shr/slicing/BloodPressureSliceByValueAndIncludesStrategy', entry, context);
+
+      expect(entry).to.eql(expected);
+    });
+  });
+
   describe('#PanelSliceByProfile()', () => {
     let PanelSliceByProfile, PanelMembers, MemberA, MemberB, Reference, Entry, ShrId, EntryId, EntryType;
     before(() => {

--- a/test/es6FromJSONTest.js
+++ b/test/es6FromJSONTest.js
@@ -8,7 +8,8 @@ let context;
 
 describe('#FromJSON', () => {
 
-  before(() => {
+  before(function() {
+    this.timeout(5000);
     context = setup('./test/fixtures/spec', 'config_stu3.json', './build/test', true);
     context.setupAjvJson('./build/test/schema');
   });

--- a/test/es6LintTest.js
+++ b/test/es6LintTest.js
@@ -4,7 +4,10 @@ const setup = require('./setup');
 
 describe.skip('#ESLint()', () => {
 
-  before(() => setup('./test/fixtures/spec', 'config_stu3.json', './build/test', true));
+  before(function() {
+    this.timeout(5000);
+    setup('./test/fixtures/spec', 'config_stu3.json', './build/test', true);
+  });
 
   it('should not have any linter errors or warnings', () => {
     const cli = new CLIEngine();

--- a/test/es6ToFHIRTest.js
+++ b/test/es6ToFHIRTest.js
@@ -7,7 +7,8 @@ require('babel-register')({
 describe('#ToFHIR', () => {
 
   let context;
-  before(() => {
+  before(function() {
+    this.timeout(5000);
     context = setup('./test/fixtures/spec', 'config_stu3.json', './build/test', true);
     context.setupAjvFhir('./test/fixtures/fhir-schema', 'FHIR_STU_3');
   });

--- a/test/es6ToJSONTest.js
+++ b/test/es6ToJSONTest.js
@@ -8,7 +8,8 @@ let context;
 
 describe('#ToJSON', () => {
 
-  before(() => {
+  before(function() {
+    this.timeout(5000);
     context = setup('./test/fixtures/spec', 'config_stu3.json', './build/test', true);
     context.setupAjvJson('./build/test/schema');
   });

--- a/test/fixtures/fhir/BloodPressureSliceByValueAndIncludesStrategy.json
+++ b/test/fixtures/fhir/BloodPressureSliceByValueAndIncludesStrategy.json
@@ -1,0 +1,27 @@
+{
+  "resourceType": "Observation",
+  "id": "1-1",
+  "meta": {
+    "profile": [
+      "http://es6-export.com/fhir/StructureDefinition/shr-slicing-BloodPressureSliceByValueAndIncludesStrategy"
+    ]
+  },
+  "component": [
+    {
+      "code": { "coding": [{ "system": "http://loinc.org", "code": "8480-6" }] },
+      "valueQuantity": {
+        "value": 120.0,
+        "system": "http://unitsofmeasure.org",
+        "code": "mm[Hg]"
+      }
+    },
+    {
+      "code": { "coding": [{ "system": "http://loinc.org", "code": "8462-4" }] },
+      "valueQuantity": {
+        "value": 80.0,
+        "system": "http://unitsofmeasure.org",
+        "code": "mm[Hg]"
+      }
+    }
+  ]
+}

--- a/test/fixtures/spec/shr_slicing.txt
+++ b/test/fixtures/spec/shr_slicing.txt
@@ -12,6 +12,11 @@ EntryElement: BloodPressureSliceByValue
 0..1 SystolicPressure
 0..1 DiastolicPressure
 
+EntryElement: BloodPressureSliceByValueAndIncludesStrategy
+0..* EvaluationComponent
+includes 0..1 SystolicPressure
+includes 0..1 DiastolicPressure
+
 Element:	SystolicPressure
 Based on: EvaluationComponent
 Concept:	LNC#8480-6

--- a/test/fixtures/spec/shr_slicing_map_stu3.txt
+++ b/test/fixtures/spec/shr_slicing_map_stu3.txt
@@ -23,3 +23,8 @@ SystolicPressure.Value maps to component.value[x]
 DiastolicPressure maps to component
 DiastolicPressure.ComponentCode maps to component.code
 DiastolicPressure.Value maps to component.value[x]
+
+BloodPressureSliceByValueAndIncludesStrategy maps to Observation:
+EvaluationComponent maps to component (slice on = code.coding.code; slice strategy = includes)
+EvaluationComponent.ComponentCode maps to component.code
+EvaluationComponent.Value maps to component.value[x]


### PR DESCRIPTION
Fixes ES6 exporter to support proper resolution of mappings that use identifiers from `IncludesType` constraints.  See: standardhealth/shr-cli#150

This was implemented test-first, so I verified that the new unit test _failed_ (as expected) before the fix, and it now passes.

You can also verify on your own against the `dev` branch of `shr_spec`:
```
$ node . ../shr_spec/spec
```

Before the this fix (e.g., [shr-cli v5.15.0](https://github.com/standardhealth/shr-cli/releases/tag/v5.15.0)), there are 181 errors reported by shr-es6-export.  After this fix, there are 0 errors.

This PR also increases test timeouts from the default (2s) to 5s, since I had cases where sometimes the test setup took longer than 2 seconds (and then failed due to timeout).