### PR TITLE
Fix issue with 'is type' in fromFHIR

### DIFF
--- a/lib/generateClass.js
+++ b/lib/generateClass.js
@@ -1185,7 +1185,9 @@ function getFieldAndMethodChain(mapping, def, specs, element) {
           field = currDef.fields.find(f => matchesEffectiveIdentifierOrIncludesTypes(f, elementIdentifier));
 
           if (field) {
-            methodName = toSymbol(field.effectiveIdentifier.name);
+            // the method name used here should be the base identifier, not the effectiveIdentifier,
+            // because in the case of "x is type y" x is the base, y is the effective type, but the field is still called x
+            methodName = toSymbol(field.identifier.name);
           }
         }
       }

--- a/test/es6FromFHIRJSONTest.js
+++ b/test/es6FromFHIRJSONTest.js
@@ -104,6 +104,29 @@ describe('#FromFHIR_STU3', () => {
     });
   });
 
+  describe('#Overriden Is Type Entry()', () => {
+    let OverrideBasedOnIntegerValueElementEntry, StringValueChild;
+
+    before(() => {
+      OverrideBasedOnIntegerValueElementEntry = context.importResult('shr/simple/OverrideBasedOnIntegerValueElementEntry');
+      StringValueChild = context.importResult('shr/simple/StringValueChild');
+    });
+
+    it('should deserialize a FHIR JSON instance', () => {
+      const json = context.getFHIR('OverrideBasedOnIntegerValueElementEntry');
+      const entry = OverrideBasedOnIntegerValueElementEntry.fromFHIR(json);
+      expect(entry).instanceOf(OverrideBasedOnIntegerValueElementEntry);
+
+      const expected = new OverrideBasedOnIntegerValueElementEntry()
+        .withStringValue(new StringValueChild().withValue('sample text'));
+
+      fixExpectedEntryInfo(expected, 'http://standardhealthrecord.org/spec/shr/simple/OverrideBasedOnIntegerValueElementEntry', entry, context);
+
+      expect(entry).to.eql(expected);
+    });
+  });
+
+
   describe('#BloodPressureSliceByNumber()', () => {
 
     let BloodPressureSliceByNumber, SystolicPressure, DiastolicPressure, ComponentCode, Quantity, Units, CodeableConcept, Coding, CodeSystem;

--- a/test/fixtures/fhir/OverrideBasedOnIntegerValueElementEntry.json
+++ b/test/fixtures/fhir/OverrideBasedOnIntegerValueElementEntry.json
@@ -1,0 +1,6 @@
+{
+  "resourceType": "Basic",
+  "code" : {
+    "text": "sample text"
+  }
+}

--- a/test/fixtures/spec/shr_simple.txt
+++ b/test/fixtures/spec/shr_simple.txt
@@ -55,7 +55,7 @@ Value:        0..1 IntegerValueElement
 
 EntryElement: BasedOnIntegerValueElementEntry
 Based on:     IntegerValueElement
-1..1          StringValue
+0..1          StringValue
 
 Element:      StringValueChild
 Based on:     StringValue

--- a/test/fixtures/spec/shr_simple_map_stu3.txt
+++ b/test/fixtures/spec/shr_simple_map_stu3.txt
@@ -1,0 +1,7 @@
+Grammar:   Map 5.0
+Namespace: shr.simple
+Target:    FHIR_STU_3
+
+
+OverrideBasedOnIntegerValueElementEntry maps to Basic:
+  StringValue maps to code.text


### PR DESCRIPTION
Addresses #39 . The `fromFHIR` generation was picking the wrong field name for fields where an "is type" constraint was defined. "is type" represents polymorphism so the field name should still be the base class even if the spec says that field should be a subclass.