### PR TITLE
Support for FHIR R4

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,6 @@
 /jsconfig.json
+/.vscode
+/.project
+/node_modules
+/out
+/build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-es6-export",
-  "version": "5.5.2",
+  "version": "5.6.0-beta.1",
   "description": "Exports ES6 classes represent SHR data elements",
   "author": "",
   "license": "Apache-2.0",
@@ -28,15 +28,15 @@
     "eslint": "^4.15.0",
     "fs-extra": "^4.0.2",
     "mocha": "^3.2.0",
-    "shr-expand": "^5.7.0",
-    "shr-fhir-export": "^5.10.0",
+    "shr-expand": "^5.8.1",
+    "shr-fhir-export": "^5.14.0-beta.1",
     "shr-json-schema-export": "^5.3.2",
-    "shr-models": "^5.5.4",
+    "shr-models": "^5.8.0",
     "shr-test-helpers": "^5.2.2",
-    "shr-text-import": "^5.5.1"
+    "shr-text-import": "^5.7.0"
   },
   "peerDependencies": {
     "bunyan": "^1.8.9",
-    "shr-models": "^5.5.4"
+    "shr-models": "^5.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "fs-extra": "^4.0.2",
     "mocha": "^3.2.0",
     "shr-expand": "^5.8.1",
-    "shr-fhir-export": "^5.14.0-beta.1",
+    "shr-fhir-export": "^5.14.0-beta.6",
     "shr-json-schema-export": "^5.3.2",
     "shr-models": "^5.8.0",
     "shr-test-helpers": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-es6-export",
-  "version": "5.6.0-beta.3",
+  "version": "5.6.0",
   "description": "Exports ES6 classes represent SHR data elements",
   "author": "",
   "license": "Apache-2.0",
@@ -29,7 +29,7 @@
     "fs-extra": "^4.0.2",
     "mocha": "^3.2.0",
     "shr-expand": "^5.8.1",
-    "shr-fhir-export": "^5.14.0-beta.6",
+    "shr-fhir-export": "^5.14.0",
     "shr-json-schema-export": "^5.3.2",
     "shr-models": "^5.8.0",
     "shr-test-helpers": "^5.2.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-es6-export",
-  "version": "5.6.0-beta.1",
+  "version": "5.6.0-beta.2",
   "description": "Exports ES6 classes represent SHR data elements",
   "author": "",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-es6-export",
-  "version": "5.6.0-beta.2",
+  "version": "5.6.0-beta.3",
   "description": "Exports ES6 classes represent SHR data elements",
   "author": "",
   "license": "Apache-2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -607,15 +607,9 @@ cross-spawn@^5.1.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-debug@2.6.8:
+debug@2.6.8, debug@^2.6.8:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
-  dependencies:
-    ms "2.0.0"
-
-debug@^2.6.8:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   dependencies:
     ms "2.0.0"
 
@@ -803,7 +797,6 @@ flat-cache@^1.2.1:
 fs-extra@^2.0.0:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-2.1.2.tgz#046c70163cef9aad46b0e4a7fa467fb22d71de35"
-  integrity sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^2.1.0"
@@ -853,7 +846,7 @@ glob@^6.0.1:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.0.3, glob@^7.0.5, glob@^7.1.2:
+glob@^7.0.3, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -886,7 +879,6 @@ globby@^5.0.0:
 graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
-  integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"
@@ -1051,7 +1043,6 @@ json5@^0.5.1:
 jsonfile@^2.1.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
-  integrity sha1-NzaitCi4e72gzIO1P6PWM6NcKug=
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -1122,7 +1113,6 @@ lodash@^4.17.4, lodash@^4.3.0:
 lodash@^4.17.5:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
 loose-envify@^1.0.0:
   version "1.3.1"
@@ -1365,13 +1355,7 @@ restore-cursor@^2.0.0:
     onetime "^2.0.0"
     signal-exit "^3.0.2"
 
-rimraf@^2.2.8:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
-  dependencies:
-    glob "^7.0.5"
-
-rimraf@~2.4.0:
+rimraf@^2.2.8, rimraf@~2.4.0:
   version "2.4.5"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.4.5.tgz#ee710ce5d93a8fdb856fb5ea8ff0e2d75934b2da"
   dependencies:
@@ -1418,12 +1402,10 @@ shebang-regex@^1.0.0:
 shr-expand@^5.8.1:
   version "5.8.1"
   resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.8.1.tgz#99aa50b7c9d8dfbe7d2c996740b8770e3d23527c"
-  integrity sha512-UyfJ9r0awLOtTdGrfJxo4q4pxp9yYQdItIKkmQTY1rywRBU6BH/CcJtox4XqAbVR+FPlL7xYngM77qGtMY+a9Q==
 
-shr-fhir-export@^5.14.0-beta.6:
-  version "5.14.0-beta.6"
-  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.14.0-beta.6.tgz#1b4758fb3b62731cf50d430e7c448145e1e62d92"
-  integrity sha512-Se9HzHvjOXIx3llEjZi6ZFJ8r9Vc7ogXZXtH+sPAIE581PfyIuY0x1qtLBVLgHXeYLJzv6gSy4T5cWvPcW18xQ==
+shr-fhir-export@^5.14.0:
+  version "5.14.0"
+  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.14.0.tgz#1217931ebfb736059f2b5c4c9e943a932881ae54"
   dependencies:
     fs-extra "^2.0.0"
     lodash "^4.17.5"
@@ -1431,12 +1413,10 @@ shr-fhir-export@^5.14.0-beta.6:
 shr-json-schema-export@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/shr-json-schema-export/-/shr-json-schema-export-5.3.2.tgz#8840b62eb6a882cb242043e93733e1f3bd472a21"
-  integrity sha512-sv8TF5VNh/JlJg5M7ZtPUSuKrKrjSsrUg11JYtpWevvfSwyfgM3T0KkL9bsyoAr1QCLwYRiosZFV89FZDregEA==
 
 shr-models@^5.8.0:
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.8.0.tgz#b2438c52340f1e167513334169d51c88bdcef5e7"
-  integrity sha512-2s5aHeXUptIfrCWPKPw27weIV5GCVyy3yXRXCxUJ+EOAJDQpyHiH54sxvCWaJ8hnRKVC+XSfx1qTMerV+T2itA==
 
 shr-test-helpers@^5.2.2:
   version "5.2.2"
@@ -1447,7 +1427,6 @@ shr-test-helpers@^5.2.2:
 shr-text-import@^5.7.0:
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/shr-text-import/-/shr-text-import-5.7.0.tgz#e2ab11b1fa183aa5a06b4b751205da8e1800b307"
-  integrity sha512-58PQXDA/JWoVDNGmnAbZM/bQyD6C/QLfp2B6HfDR6dCuixa2M9fpDnInnzfIKd6wFi3OLv3Z8jJtb4NjnnykZA==
   dependencies:
     antlr4 "~4.6.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1420,10 +1420,10 @@ shr-expand@^5.8.1:
   resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.8.1.tgz#99aa50b7c9d8dfbe7d2c996740b8770e3d23527c"
   integrity sha512-UyfJ9r0awLOtTdGrfJxo4q4pxp9yYQdItIKkmQTY1rywRBU6BH/CcJtox4XqAbVR+FPlL7xYngM77qGtMY+a9Q==
 
-shr-fhir-export@^5.14.0-beta.1:
-  version "5.14.0-beta.1"
-  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.14.0-beta.1.tgz#0e2600aa9e8cba13dc020989eec33a375777a9e5"
-  integrity sha512-Stz1gIiG5YUIFC1V6dLW8wvCqfC3+BiS0/nx5MFw1Yqx2k+u5gqhSdR4gK/RogXqt/IPW3mum8wjTRFElv6Fvg==
+shr-fhir-export@^5.14.0-beta.6:
+  version "5.14.0-beta.6"
+  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.14.0-beta.6.tgz#1b4758fb3b62731cf50d430e7c448145e1e62d92"
+  integrity sha512-Se9HzHvjOXIx3llEjZi6ZFJ8r9Vc7ogXZXtH+sPAIE581PfyIuY0x1qtLBVLgHXeYLJzv6gSy4T5cWvPcW18xQ==
   dependencies:
     fs-extra "^2.0.0"
     lodash "^4.17.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1415,15 +1415,15 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
-shr-expand@^5.7.0:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.7.0.tgz#a9bd0d2c099dada0345b734613252c55e61710ba"
-  integrity sha512-wUJDV/uusXSM3ZSUTY1xsGhO5XTZcIvUqYC0r2lQBOIlkF76CmFNW048c1av5gJwjTD1s534PYKcM65jGxPWqw==
+shr-expand@^5.8.1:
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.8.1.tgz#99aa50b7c9d8dfbe7d2c996740b8770e3d23527c"
+  integrity sha512-UyfJ9r0awLOtTdGrfJxo4q4pxp9yYQdItIKkmQTY1rywRBU6BH/CcJtox4XqAbVR+FPlL7xYngM77qGtMY+a9Q==
 
-shr-fhir-export@^5.10.0:
-  version "5.10.0"
-  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.10.0.tgz#c53cac7cfd29173829411037791725da2927124e"
-  integrity sha512-ol4jVXQxLp8IBQD9ZioeL5wB4/55ZdF5Qd1VaErusY5yYJaV3BgO3YQr8JgG1WgQq0DAHituGFyANbuMZaZ9ww==
+shr-fhir-export@^5.14.0-beta.1:
+  version "5.14.0-beta.1"
+  resolved "https://registry.yarnpkg.com/shr-fhir-export/-/shr-fhir-export-5.14.0-beta.1.tgz#0e2600aa9e8cba13dc020989eec33a375777a9e5"
+  integrity sha512-Stz1gIiG5YUIFC1V6dLW8wvCqfC3+BiS0/nx5MFw1Yqx2k+u5gqhSdR4gK/RogXqt/IPW3mum8wjTRFElv6Fvg==
   dependencies:
     fs-extra "^2.0.0"
     lodash "^4.17.5"
@@ -1433,10 +1433,10 @@ shr-json-schema-export@^5.3.2:
   resolved "https://registry.yarnpkg.com/shr-json-schema-export/-/shr-json-schema-export-5.3.2.tgz#8840b62eb6a882cb242043e93733e1f3bd472a21"
   integrity sha512-sv8TF5VNh/JlJg5M7ZtPUSuKrKrjSsrUg11JYtpWevvfSwyfgM3T0KkL9bsyoAr1QCLwYRiosZFV89FZDregEA==
 
-shr-models@^5.5.4:
-  version "5.5.4"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.5.4.tgz#f37490ed25cf4e33e8d013c412687fdfa474afd5"
-  integrity sha512-+kIVWYSPYdFVN3ik1MKfTR1etAxBsugQD8V6cItr1qpqcLra/qNM2yp/IzJ6+E2PhycZojYJpkd+NsaU4TaaPg==
+shr-models@^5.8.0:
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.8.0.tgz#b2438c52340f1e167513334169d51c88bdcef5e7"
+  integrity sha512-2s5aHeXUptIfrCWPKPw27weIV5GCVyy3yXRXCxUJ+EOAJDQpyHiH54sxvCWaJ8hnRKVC+XSfx1qTMerV+T2itA==
 
 shr-test-helpers@^5.2.2:
   version "5.2.2"
@@ -1444,9 +1444,10 @@ shr-test-helpers@^5.2.2:
   dependencies:
     fs-extra "^5.0.0"
 
-shr-text-import@^5.5.1:
-  version "5.5.1"
-  resolved "https://registry.yarnpkg.com/shr-text-import/-/shr-text-import-5.5.1.tgz#04c6d61a5cc543048cfc846da38d9877b95c59ab"
+shr-text-import@^5.7.0:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/shr-text-import/-/shr-text-import-5.7.0.tgz#e2ab11b1fa183aa5a06b4b751205da8e1800b307"
+  integrity sha512-58PQXDA/JWoVDNGmnAbZM/bQyD6C/QLfp2B6HfDR6dCuixa2M9fpDnInnzfIKd6wFi3OLv3Z8jJtb4NjnnykZA==
   dependencies:
     antlr4 "~4.6.0"
 


### PR DESCRIPTION
This PR updates shr-es6-export to support R4.  The two main things to consider are:
* FHIR R4 types have `profile` and `targetProfile` as arrays (more like DSTU2 than STU3)
* FHIR R4 value set bindings use propertyName `valueSet` (instead of `valueSetUri`/`valueSetReference`

I also updated some of the other shr dependencies that hadn't been updated in a while.

Making this a DRAFT PR because I don't want it merged until it's been reviewed *and* I've dropped beta from the version number.