### PR TITLE
Class registry concept

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -150,7 +150,7 @@ class ES6Exporter {
       .ln()
       .ln(`const getClass = (filename) => require(filename).default;`)
       .ln()
-      .ln('export const ClassRegistry = {')
+      .ln('const ClassRegistry = {')
       .indent();
 
     for (const ns of namespaces) {
@@ -171,7 +171,9 @@ class ES6Exporter {
     }
 
     cw.outdent()
-      .ln('};');
+      .ln('};')
+      .ln()
+      .ln('export default ClassRegistry;');
 
     return cw.toString();
   }

--- a/lib/export.js
+++ b/lib/export.js
@@ -148,8 +148,6 @@ class ES6Exporter {
     cw.ln(`// GENERATED CODE`)
       .ln(`// Manual modification is NOT RECOMMENDED as changes will be overwritten the next time the classes are generated.`)
       .ln()
-      .ln(`const getClass = (filename) => require(filename).default;`)
-      .ln()
       .ln('const ClassRegistry = {')
       .indent();
 
@@ -163,7 +161,7 @@ class ES6Exporter {
         const elName = className(def.identifier.name);
         // import the files directly in the map for brevity.
         // the alternative is a long list of imports at the top and separate references in the map
-        cw.ln(`'${elName}': getClass('./${def.identifier.fqn.split('.').join('/')}'),`);
+        cw.ln(`'${elName}': require('./${def.identifier.fqn.split('.').join('/')}').default,`);
       }
 
       cw.outdent()

--- a/lib/export.js
+++ b/lib/export.js
@@ -76,6 +76,7 @@ class ES6Exporter {
     es6Defs['ObjectFactory.js'] = generateFactory(namespaces);
 
     es6Defs['valueSets.js'] = this.collectValueSets(this._fhir);
+    es6Defs['ClassRegistry.js'] = this.createClassRegistry(namespaces);
 
     return es6Defs;
   }
@@ -87,7 +88,10 @@ class ES6Exporter {
    */
   collectValueSets(fhir) {
     const cw = new CodeWriter();
-    cw.ln('export const ALL_KNOWN_VALUE_SETS = {')
+    cw.ln(`// GENERATED CODE`)
+      .ln(`// Manual modification is NOT RECOMMENDED as changes will be overwritten the next time the classes are generated.`)
+      .ln()
+      .ln('export const ALL_KNOWN_VALUE_SETS = {')
       .indent();
 
     const alreadySeen = new Set;
@@ -125,6 +129,53 @@ class ES6Exporter {
 
     return cw.toString();
   }
+
+  /**
+   * Build up a "registry" of classes given their names.
+   * The idea here is that there are known bugs with the exporter
+   * and in many cases it's much quicker to manually apply fixes
+   * to the generated classes than fix the actual bug in the exporter.
+   * Users of the classes should subclass the affected classes, then update the class registry
+   * (in a separate location, since the file is generated)
+   * with a reference to the new class. This makes it easier to preserve the fixes
+   * across re-generations of the classes.
+   *
+   * Format: { 'namespace1': { 'ClassName': ClassObject, ... }, ... }
+   */
+  createClassRegistry(namespaces) {
+    const cw = new CodeWriter();
+
+    cw.ln(`// GENERATED CODE`)
+      .ln(`// Manual modification is NOT RECOMMENDED as changes will be overwritten the next time the classes are generated.`)
+      .ln()
+      .ln(`const getClass = (filename) => require(filename).default;`)
+      .ln()
+      .ln('export const ClassRegistry = {')
+      .indent();
+
+    for (const ns of namespaces) {
+      cw.ln(`'${ns.namespace}': {`)
+        .indent();
+
+      const defs = this._specs.dataElements.byNamespace(ns.namespace);
+
+      for (const def of defs) {
+        const elName = className(def.identifier.name);
+        // import the files directly in the map for brevity.
+        // the alternative is a long list of imports at the top and separate references in the map
+        cw.ln(`'${elName}': getClass('./${def.identifier.fqn.split('.').join('/')}'),`);
+      }
+
+      cw.outdent()
+        .ln('},');
+    }
+
+    cw.outdent()
+      .ln('};');
+
+    return cw.toString();
+  }
+
 }
 
 module.exports = {exportToES6, setLogger, MODELS_INFO};

--- a/lib/generateClass.js
+++ b/lib/generateClass.js
@@ -30,6 +30,10 @@ function generateClass(def, specs, fhir) {
   try {
     const cw = new CodeWriter();
 
+    cw.ln(`// GENERATED CODE`)
+      .ln(`// Manual modification is NOT RECOMMENDED as changes will be overwritten the next time the class is generated.`)
+      .ln();
+
     const imports = ['setPropertiesFromJSON', 'uuid'];
 
     const defFhirID = fhirID(def.identifier);

--- a/lib/generateFactory.js
+++ b/lib/generateFactory.js
@@ -8,6 +8,9 @@ const { factoryName } = require('./common.js');
  */
 function generateFactory(namespaces) {
   const cw = new CodeWriter();
+  cw.ln(`// GENERATED CODE`)
+    .ln(`// Manual modification is NOT RECOMMENDED as changes will be overwritten the next time the classes are generated.`)
+    .ln();
   cw.ln(`import { getNamespaceAndName, getNamespaceAndNameFromFHIR, uuid } from './json-helper';`);
   for (const ns of namespaces) {
     const factory = factoryName(ns.namespace);

--- a/lib/generateNamespaceFactory.js
+++ b/lib/generateNamespaceFactory.js
@@ -53,7 +53,7 @@ function generateNamespaceFactory(ns, defs) {
             })
             .ln(`const klass = ClassRegistry['${ns.namespace}'][elementName];`)
             .bl(`if (!klass)`, ()=> {
-              cw.ln(`throw new Error(\`Unsupported type in ${factory}: \${type}\`);`);
+              cw.ln(`throw new Error(\`Unsupported type in ${factory}: \${shrType}\`);`);
             })
             .ln(`return klass.fromFHIR(fhir, fhirType, shrId, allEntries, mappedResources, referencesOut, asExtension);`);
         });

--- a/lib/generateNamespaceFactory.js
+++ b/lib/generateNamespaceFactory.js
@@ -9,11 +9,12 @@ const { className, factoryName } = require('./common.js');
  */
 function generateNamespaceFactory(ns, defs) {
   const cw = new CodeWriter();
+  cw.ln(`// GENERATED CODE`)
+    .ln(`// Manual modification is NOT RECOMMENDED as changes will be overwritten the next time the classes are generated.`)
+    .ln();
   cw.ln(`import { getNamespaceAndName, getNamespaceAndNameFromFHIR, uuid } from '${relativeImportPath(ns.namespace, 'json-helper')}';`);
-  for (const def of defs) {
-    const name = className(def.identifier.name);
-    cw.ln(`import ${name} from './${name}';`);
-  }
+  cw.ln(`import { ClassRegistry } from '${relativeImportPath(ns.namespace, 'ClassRegistry')}';`)
+
   const factory = factoryName(ns.namespace);
   cw.ln()
     .blComment(`Generated object factory for the ${ns.namespace} namespace.`)
@@ -29,13 +30,11 @@ function generateNamespaceFactory(ns, defs) {
             .bl(`if (namespace !== '${ns.namespace}')`, () => {
               cw.ln(`throw new Error(\`Unsupported type in ${factory}: \${type}\`);`);
             })
-            .ln('switch (elementName) {');
-          for (const def of defs) {
-            const elName = className(def.identifier.name);
-            cw.ln(`case '${elName}': return ${elName}.fromJSON(json);`);
-          }
-          cw.ln(`default: throw new Error(\`Unsupported type in ${factory}: \${type}\`);`)
-            .ln('}');
+            .ln(`const klass = ClassRegistry['${ns.namespace}'][elementName];`)
+            .bl(`if (!klass)`, ()=> {
+              cw.ln(`throw new Error(\`Unsupported type in ${factory}: \${type}\`);`);
+            })
+            .ln(`return klass.fromJSON(json);`);
         });
 
       cw.ln();
@@ -52,13 +51,11 @@ function generateNamespaceFactory(ns, defs) {
             .bl(`if (namespace !== '${ns.namespace}')`, () => {
               cw.ln(`throw new Error(\`Unsupported type in ${factory}: \${shrType}\`);`);
             })
-            .ln('switch (elementName) {');
-          for (const def of defs) {
-            const elName = className(def.identifier.name);
-            cw.ln(`case '${elName}': return ${elName}.fromFHIR(fhir, fhirType, shrId, allEntries, mappedResources, referencesOut, asExtension);`);
-          }
-          cw.ln(`default: throw new Error(\`Unsupported type in ${factory}: \${shrType}\`);`)
-            .ln('}');
+            .ln(`const klass = ClassRegistry['${ns.namespace}'][elementName];`)
+            .bl(`if (!klass)`, ()=> {
+              cw.ln(`throw new Error(\`Unsupported type in ${factory}: \${type}\`);`);
+            })
+            .ln(`return klass.fromFHIR(fhir, fhirType, shrId, allEntries, mappedResources, referencesOut, asExtension);`);
         });
     });
   return cw.toString();

--- a/lib/generateNamespaceFactory.js
+++ b/lib/generateNamespaceFactory.js
@@ -13,7 +13,7 @@ function generateNamespaceFactory(ns, defs) {
     .ln(`// Manual modification is NOT RECOMMENDED as changes will be overwritten the next time the classes are generated.`)
     .ln();
   cw.ln(`import { getNamespaceAndName, getNamespaceAndNameFromFHIR, uuid } from '${relativeImportPath(ns.namespace, 'json-helper')}';`);
-  cw.ln(`import { ClassRegistry } from '${relativeImportPath(ns.namespace, 'ClassRegistry')}';`)
+  cw.ln(`import ClassRegistry from '${relativeImportPath(ns.namespace, 'ClassRegistry')}';`)
 
   const factory = factoryName(ns.namespace);
   cw.ln()

--- a/lib/includes/init.js
+++ b/lib/includes/init.js
@@ -1,5 +1,6 @@
 import {setObjectFactory} from './json-helper';
 import ObjectFactory from './ObjectFactory';
+// import {ClassRegistry} from './ClassRegistry';
 
 /**
  * The init function initializes the ES helper functions with the necessary dependencies for creating
@@ -10,6 +11,10 @@ import ObjectFactory from './ObjectFactory';
  */
 function init() {
   setObjectFactory(ObjectFactory);
+
+  // Overwrite any classes in the class registry as needed here:
+  // for example,
+  // ClassRegistry['namespace.SomeClass'] = SomeClassExtended;
 }
 
 init();

--- a/lib/includes/init.js
+++ b/lib/includes/init.js
@@ -1,6 +1,6 @@
 import {setObjectFactory} from './json-helper';
 import ObjectFactory from './ObjectFactory';
-// import {ClassRegistry} from './ClassRegistry';
+// import ClassRegistry from './ClassRegistry';
 
 /**
  * The init function initializes the ES helper functions with the necessary dependencies for creating
@@ -14,7 +14,7 @@ function init() {
 
   // Overwrite any classes in the class registry as needed here:
   // for example,
-  // ClassRegistry['namespace.SomeClass'] = SomeClassExtended;
+  // ClassRegistry['namespace']['SomeClass'] = SomeClassExtended;
 }
 
 init();

--- a/test/es6FromFHIRJSONTest.js
+++ b/test/es6FromFHIRJSONTest.js
@@ -464,6 +464,35 @@ describe('#FromFHIR_STU3', () => {
       expect(spy).to.have.been.called.with('CodeableConcept');
     });
   });
+
+  describe('#ClassRegistry', () => {
+    let ClassRegistry, ObjectFactory, Observation;
+
+    before(() => {
+      ClassRegistry = context.importResult('ClassRegistry');
+      ObjectFactory = context.importResult('ObjectFactory');
+      Observation = context.importResult('shr/slicing/Observation');
+    });
+
+    it('should correctly call a class registered in the class registry', () => {
+      const json = context.getFHIR('Observation');
+      const anonymousSubclass = class extends Observation {
+        static fromFHIR(fhir, fhirType, shrId=null, allEntries=null, mappedResources=null, referencesOut=null, asExtension=null) {
+          // do nothing, we don't care about the result just that it was called
+        }
+      };
+
+      ClassRegistry['shr.slicing']['Observation'] = anonymousSubclass;
+
+      const spyOriginalClass = chai.spy.on(Observation, 'fromFHIR');
+      const spyReplacementClass = chai.spy.on(anonymousSubclass, 'fromFHIR');
+
+      ObjectFactory.createInstanceFromFHIR('shr.slicing.Observation', {}, null);
+
+      expect(spyOriginalClass).to.not.have.been.called();
+      expect(spyReplacementClass).to.have.been.called();
+    });
+  });
 });
 
 describe('#FromFHIR_DSTU2', () => {


### PR DESCRIPTION
Implements the concept of a "class registry" where the implementation of a class is not directly referenced but instead looked up in a lookup table. This allows for the classes to be subclassed and then plugged into the lookup table, allowing for the rest of the code to reference the subclasses instead. The reason for this is that we know there are a number of remaining issues with the exporter, so this approach will allow for users to manually apply fixes to the generated classes as subclasses, which are then preserved across re-generations of the code. Ideally this should be a lot easier than making and re-applying one's changes every time the classes get re-generated.