### PR TITLE
Lint fixes

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,3 @@
 # /node_modules/* and /bower_components/* ignored by default
+# comment out the line below to see lint errors on generated code
+/build

--- a/lib/generateNamespaceFactory.js
+++ b/lib/generateNamespaceFactory.js
@@ -1,5 +1,5 @@
 const CodeWriter = require('./CodeWriter');
-const { className, factoryName } = require('./common.js');
+const { factoryName } = require('./common.js');
 
 /**
  * Generates a namespace-level factory class for instantiating ES6 classes based on element name and entry data.
@@ -13,7 +13,7 @@ function generateNamespaceFactory(ns, defs) {
     .ln(`// Manual modification is NOT RECOMMENDED as changes will be overwritten the next time the classes are generated.`)
     .ln();
   cw.ln(`import { getNamespaceAndName, getNamespaceAndNameFromFHIR, uuid } from '${relativeImportPath(ns.namespace, 'json-helper')}';`);
-  cw.ln(`import ClassRegistry from '${relativeImportPath(ns.namespace, 'ClassRegistry')}';`)
+  cw.ln(`import ClassRegistry from '${relativeImportPath(ns.namespace, 'ClassRegistry')}';`);
 
   const factory = factoryName(ns.namespace);
   cw.ln()

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "lint:fix": "./node_modules/.bin/eslint . --fix"
   },
   "dependencies": {
-    "chai-spies": "^1.0.0",
     "reserved-words": "^0.1.2"
   },
   "devDependencies": {
@@ -26,6 +25,7 @@
     "babel-register": "^6.26.0",
     "bunyan": "^1.8.9",
     "chai": "^3.5.0",
+    "chai-spies": "^1.0.0",
     "eslint": "^4.15.0",
     "fs-extra": "^4.0.2",
     "mocha": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-es6-export",
-  "version": "5.7.0",
+  "version": "5.7.1",
   "description": "Exports ES6 classes represent SHR data elements",
   "author": "",
   "license": "Apache-2.0",

--- a/test/es6FromFHIRJSONTest.js
+++ b/test/es6FromFHIRJSONTest.js
@@ -449,7 +449,7 @@ describe('#FromFHIR_STU3', () => {
         // this will error out because DataValue.fromFHIR doesn't know what to do with the given fhir (yet)
         // but at this point all we care about is that it's passed the right parameter
         Observation.fromFHIR(json1, 'Observation', '1-1');
-      } catch (e) {} 
+      } catch (e) { /* for now do nothing */ }
 
       expect(spy).to.have.been.called.with('string');
 
@@ -459,7 +459,7 @@ describe('#FromFHIR_STU3', () => {
         // this will error out because DataValue.fromFHIR doesn't know what to do with the given fhir (yet)
         // but at this point all we care about is that it's passed the right parameter
         Observation.fromFHIR(json2, 'Observation', '1-1');
-      } catch (e) {} 
+      } catch (e) { /* for now do nothing */ }
 
       expect(spy).to.have.been.called.with('CodeableConcept');
     });
@@ -475,7 +475,6 @@ describe('#FromFHIR_STU3', () => {
     });
 
     it('should correctly call a class registered in the class registry', () => {
-      const json = context.getFHIR('Observation');
       const anonymousSubclass = class extends Observation {
         static fromFHIR(fhir, fhirType, shrId=null, allEntries=null, mappedResources=null, referencesOut=null, asExtension=null) {
           // do nothing, we don't care about the result just that it was called


### PR DESCRIPTION
Fixes some errors reported by `yarn:lint` and moves `chai-spies` to `devDependencies` since it is only used in tests.  Also bumps version up by a patch.