### PR TITLE
Class Registry updates

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -131,7 +131,7 @@ class ES6Exporter {
   }
 
   /**
-   * Build up a "registry" of classes given their names.
+   * Build up a "registry" of classes given their namespace/name.
    * The idea here is that there are known bugs with the exporter
    * and in many cases it's much quicker to manually apply fixes
    * to the generated classes than fix the actual bug in the exporter.
@@ -140,7 +140,7 @@ class ES6Exporter {
    * with a reference to the new class. This makes it easier to preserve the fixes
    * across re-generations of the classes.
    *
-   * Format: { 'namespace1': { 'ClassName': ClassObject, ... }, ... }
+   * Underlying format: { 'namespace1': { 'ClassName': ClassObject, ... }, ... }
    */
   createClassRegistry(namespaces) {
     const cw = new CodeWriter();
@@ -148,30 +148,72 @@ class ES6Exporter {
     cw.ln(`// GENERATED CODE`)
       .ln(`// Manual modification is NOT RECOMMENDED as changes will be overwritten the next time the classes are generated.`)
       .ln()
-      .ln('const ClassRegistry = {')
-      .indent();
-
-    for (const ns of namespaces) {
-      cw.ln(`'${ns.namespace}': {`)
-        .indent();
-
-      const defs = this._specs.dataElements.byNamespace(ns.namespace);
-
-      for (const def of defs) {
-        const elName = className(def.identifier.name);
-        // import the files directly in the map for brevity.
-        // the alternative is a long list of imports at the top and separate references in the map
-        cw.ln(`'${elName}': require('./${def.identifier.fqn.split('.').join('/')}').default,`);
-      }
-
-      cw.outdent()
-        .ln('},');
-    }
-
-    cw.outdent()
-      .ln('};')
       .ln()
+      .blComment(() => {
+        cw.ln('The Class Registry concept is designed to allow for users of the SHR ES6 classes to fix bugs and add extensions')
+          .ln('in a way that makes maintaining those changes across re-generations easier.')
+          .ln('Users should subclass any relevant classes, then update the class registry')
+          .ln('(in a separate location, since the file is generated)')
+          .ln('with a reference to the new class.')
+          .ln('Note: this class structure is needed to avoid circular dependency issues,')
+          .ln('as this refers to all the individual ES6 classes, and the individual ES6 classes all refer to this.')
+      })
+      .bl('class Registry', () => {
+
+        cw.bl('initialize()', () => {
+          cw.ln('this.internalRegistry = {')
+            .indent();
+
+          for (const ns of namespaces) {
+            cw.ln(`'${ns.namespace}': {`)
+              .indent();
+
+            const defs = this._specs.dataElements.byNamespace(ns.namespace);
+
+            for (const def of defs) {
+              const elName = className(def.identifier.name);
+              // import the files directly in the map for brevity.
+              // the alternative is a long list of imports at the top and separate references in the map
+              cw.ln(`'${elName}': require('./${def.identifier.fqn.split('.').join('/')}').default,`);
+            }
+
+            cw.outdent()
+              .ln('},');
+          }
+
+        cw.outdent()
+          .ln('};');
+        })
+          .ln()
+          .blComment(() => {
+            cw.ln('Get the class object for the given namespace and model class name.')
+              .ln('I.e., the actual class is returned, not an instance of it.')
+              .ln('In most cases this will be the original class,')
+              .ln('but when a subclass has been defined and registered then it will be returned here.')
+              .ln('@param {string} namespace - The full namespace of the desired class, ex. \'shr.base\'.')
+              .ln('@param {string} name - The name of the class, ex. \'Entry\'')
+              .ln('@return {Class} the desired class or a subclass of it with fixes/extensions')
+          })
+          .bl('get(namespace, name)', () => {
+          cw.ln('return this.internalRegistry[namespace][name];')
+        })
+          .ln()
+          .blComment(() => {
+            cw.ln('Register a replacement class object for the given namespace and model class name.')
+              .ln('Note that this does no validation that the given class is a true drop-in replacement of the original class')
+              .ln('@param {string} namespace - The full namespace of the class, ex. \'shr.base\'.')
+              .ln('@param {string} name - The name of the class, ex. \'Entry\'')
+              .ln('@param {Class} klass - The new class object to be returned when ')
+          })
+          .bl('set(namespace, name, klass)', () => {
+            cw.ln('this.internalRegistry[namespace][name] = klass;')
+        });
+      })
+      .ln()
+      .ln('// singleton pattern')
+      .ln('const ClassRegistry = new Registry();')
       .ln('export default ClassRegistry;');
+
 
     return cw.toString();
   }

--- a/lib/export.js
+++ b/lib/export.js
@@ -156,7 +156,7 @@ class ES6Exporter {
           .ln('(in a separate location, since the file is generated)')
           .ln('with a reference to the new class.')
           .ln('Note: this class structure is needed to avoid circular dependency issues,')
-          .ln('as this refers to all the individual ES6 classes, and the individual ES6 classes all refer to this.')
+          .ln('as this refers to all the individual ES6 classes, and the individual ES6 classes all refer to this.');
       })
       .bl('class Registry', () => {
 
@@ -181,8 +181,8 @@ class ES6Exporter {
               .ln('},');
           }
 
-        cw.outdent()
-          .ln('};');
+          cw.outdent()
+            .ln('};');
         })
           .ln()
           .blComment(() => {
@@ -192,22 +192,22 @@ class ES6Exporter {
               .ln('but when a subclass has been defined and registered then it will be returned here.')
               .ln('@param {string} namespace - The full namespace of the desired class, ex. \'shr.base\'.')
               .ln('@param {string} name - The name of the class, ex. \'Entry\'')
-              .ln('@return {Class} the desired class or a subclass of it with fixes/extensions')
+              .ln('@return {Class} the desired class or a subclass of it with fixes/extensions');
           })
           .bl('get(namespace, name)', () => {
-          cw.ln('return this.internalRegistry[namespace][name];')
-        })
+            cw.ln('return this.internalRegistry[namespace][name];');
+          })
           .ln()
           .blComment(() => {
             cw.ln('Register a replacement class object for the given namespace and model class name.')
               .ln('Note that this does no validation that the given class is a true drop-in replacement of the original class')
               .ln('@param {string} namespace - The full namespace of the class, ex. \'shr.base\'.')
               .ln('@param {string} name - The name of the class, ex. \'Entry\'')
-              .ln('@param {Class} klass - The new class object to be returned when ')
+              .ln('@param {Class} klass - The new class object to be returned when ');
           })
           .bl('set(namespace, name, klass)', () => {
-            cw.ln('this.internalRegistry[namespace][name] = klass;')
-        });
+            cw.ln('this.internalRegistry[namespace][name] = klass;');
+          });
       })
       .ln()
       .ln('// singleton pattern')

--- a/lib/generateClass.js
+++ b/lib/generateClass.js
@@ -50,6 +50,8 @@ function generateClass(def, specs, fhir) {
     }
 
     cw.ln(`import { ${imports.join(', ')} } from '${relativeImportPath(def.identifier, 'json-helper')}';`).ln();
+    cw.ln(`import ClassRegistry from '${relativeImportPath(def.identifier, 'ClassRegistry')}';`).ln();
+
     const clazzName = className(def.identifier.name);
     let superClass;
     if (def.basedOn.length) {
@@ -297,7 +299,8 @@ function writeGetterAndSetter(cw, clazzName, formalDefOrName, publicSymbol, desc
  * @private
  */
 function writeFromJson(def, cw) {
-  cw.ln(`const inst = new ${className(def.identifier.name)}();`);
+  cw.ln(`const klass = ClassRegistry.get('${def.identifier.namespace}', '${className(def.identifier.name)}');`)
+  cw.ln(`const inst = new klass();`);
   cw.ln('setPropertiesFromJSON(inst, json);');
   cw.ln('return inst;');
 }
@@ -476,7 +479,8 @@ function childElementsOf(parent, allElements) {
  * @private
  */
 function writeFromFhir(def, specs, fhir, fhirProfile, fhirExtension, cw) {
-  cw.ln(`const inst = new ${className(def.identifier.name)}();`);
+  cw.ln(`const klass = ClassRegistry.get('${def.identifier.namespace}', '${className(def.identifier.name)}');`)
+  cw.ln(`const inst = new klass();`);
 
   if (def.isEntry) {
     cw.ln(`inst.entryInfo = FHIRHelper.createInstanceFromFHIR('shr.base.Entry', {}, null);`); // do it this way so we don't have to import Entry

--- a/lib/generateClass.js
+++ b/lib/generateClass.js
@@ -299,7 +299,7 @@ function writeGetterAndSetter(cw, clazzName, formalDefOrName, publicSymbol, desc
  * @private
  */
 function writeFromJson(def, cw) {
-  cw.ln(`const klass = ClassRegistry.get('${def.identifier.namespace}', '${className(def.identifier.name)}');`)
+  cw.ln(`const klass = ClassRegistry.get('${def.identifier.namespace}', '${className(def.identifier.name)}');`);
   cw.ln(`const inst = new klass();`);
   cw.ln('setPropertiesFromJSON(inst, json);');
   cw.ln('return inst;');
@@ -479,7 +479,7 @@ function childElementsOf(parent, allElements) {
  * @private
  */
 function writeFromFhir(def, specs, fhir, fhirProfile, fhirExtension, cw) {
-  cw.ln(`const klass = ClassRegistry.get('${def.identifier.namespace}', '${className(def.identifier.name)}');`)
+  cw.ln(`const klass = ClassRegistry.get('${def.identifier.namespace}', '${className(def.identifier.name)}');`);
   cw.ln(`const inst = new klass();`);
 
   if (def.isEntry) {

--- a/lib/generateNamespaceFactory.js
+++ b/lib/generateNamespaceFactory.js
@@ -30,7 +30,7 @@ function generateNamespaceFactory(ns, defs) {
             .bl(`if (namespace !== '${ns.namespace}')`, () => {
               cw.ln(`throw new Error(\`Unsupported type in ${factory}: \${type}\`);`);
             })
-            .ln(`const klass = ClassRegistry['${ns.namespace}'][elementName];`)
+            .ln(`const klass = ClassRegistry.get('${ns.namespace}', elementName);`)
             .bl(`if (!klass)`, ()=> {
               cw.ln(`throw new Error(\`Unsupported type in ${factory}: \${type}\`);`);
             })
@@ -51,7 +51,7 @@ function generateNamespaceFactory(ns, defs) {
             .bl(`if (namespace !== '${ns.namespace}')`, () => {
               cw.ln(`throw new Error(\`Unsupported type in ${factory}: \${shrType}\`);`);
             })
-            .ln(`const klass = ClassRegistry['${ns.namespace}'][elementName];`)
+            .ln(`const klass = ClassRegistry.get('${ns.namespace}', elementName);`)
             .bl(`if (!klass)`, ()=> {
               cw.ln(`throw new Error(\`Unsupported type in ${factory}: \${shrType}\`);`);
             })

--- a/lib/includes/init.js
+++ b/lib/includes/init.js
@@ -1,6 +1,6 @@
 import {setObjectFactory} from './json-helper';
 import ObjectFactory from './ObjectFactory';
-// import ClassRegistry from './ClassRegistry';
+import ClassRegistry from './ClassRegistry';
 
 /**
  * The init function initializes the ES helper functions with the necessary dependencies for creating
@@ -12,6 +12,7 @@ import ObjectFactory from './ObjectFactory';
 function init() {
   setObjectFactory(ObjectFactory);
 
+  ClassRegistry.initialize();
   // Overwrite any classes in the class registry as needed here:
   // for example,
   // ClassRegistry['namespace']['SomeClass'] = SomeClassExtended;

--- a/lib/includes/init.js
+++ b/lib/includes/init.js
@@ -13,9 +13,6 @@ function init() {
   setObjectFactory(ObjectFactory);
 
   ClassRegistry.initialize();
-  // Overwrite any classes in the class registry as needed here:
-  // for example,
-  // ClassRegistry['namespace']['SomeClass'] = SomeClassExtended;
 }
 
 init();

--- a/lib/includes/json-helper.js
+++ b/lib/includes/json-helper.js
@@ -230,11 +230,11 @@ export const FHIRHelper = {
   },
 
   createReferenceWithoutObject: function(shrId, entryId, entryType) {
-     return new Reference(
+    return new Reference(
       createInstance('shr.base.ShrId', { Value: shrId }),
       createInstance('shr.base.EntryId', { Value: entryId }),
       createInstance('shr.base.EntryType', { Value: entryType })
-     );
+    );
   },
 
   /**

--- a/lib/includes/json-helper.js
+++ b/lib/includes/json-helper.js
@@ -1,11 +1,5 @@
 import Reference from './Reference';
-import Entry from './shr/base/Entry';
-import ShrId from './shr/base/ShrId';
-import EntryId from './shr/base/EntryId';
-import EntryType from './shr/base/EntryType';
-
 import { ALL_KNOWN_VALUE_SETS } from './valueSets';
-
 
 // A variable to hold the root ObjectFactory.  This can be set via the exported setObjectFactory function,
 // but should typically be set by importing the module's init file.
@@ -25,7 +19,7 @@ export function setObjectFactory(factory) {
 /**
  * Parses the JSON and/or type to return an object with the namespace and elementName.
  * @param {Object} json - The element data in JSON format (use `{}` and provide `type` for a blank instance)
- * @param {string} [type] - The (optional) type of the element (e.g., 'http://standardhealthrecord.org/spec/shr/demographics/PersonOfRecord').  This is only used if the type cannot be extracted from the JSON.
+ * @param {string} [type] - The (optional) type of the element (e.g., 'http://standardhealthrecord.org/spec/shr/base/Patient' or 'shr.base.Patient').  This is only used if the type cannot be extracted from the JSON.
  * @returns {{namespace: string, elementName: string}} An object representing the element
  */
 export function getNamespaceAndName(json={}, type) {
@@ -45,6 +39,12 @@ export function getNamespaceAndName(json={}, type) {
     const namespace = uriMatch[1].split('/').join('.');
     const elementName = uriMatch[2];
     return { namespace, elementName };
+  } else if (type.indexOf('.') !== -1) {
+    // assume it's of the form namespace.ClassName
+    const lastDot = type.lastIndexOf('.');
+    const namespace = type.slice(0, lastDot);
+    const elementName = type.slice(lastDot + 1); // don't include the dot
+    return { namespace, elementName };
   }
   // No match, so throw an error
   throw new Error(`Illegal element type: ${type}`);
@@ -58,8 +58,12 @@ export function getNamespaceAndName(json={}, type) {
  */
 export function getNamespaceAndNameFromFHIR(fhir, type) {
   // Special case for primitives
-  if (typeof fhir !== 'object' && type != null && type.indexOf('.') === -1) {
-    return { namespace: 'primitive', elementName: type };
+  if (typeof fhir !== 'object') {
+    if (type == null) {
+      return { namespace: 'primitive', elementName: typeof fhir };
+    } else if (type.indexOf('.') === -1) {
+      return { namespace: 'primitive', elementName: type };
+    }
   }
   // Get the type from the JSON if we can
   if (fhir['meta'] && fhir['meta']['profile']) {
@@ -150,7 +154,8 @@ function findSetterForEntryProperty(inst, property) {
   if (entryInfoSetter) {
     // Now see if there is an existing entryInfo, and if not, set it to a new instance
     if (typeof inst.entryInfo === 'undefined') {
-      entryInfoSetter.call(inst, new Entry());
+      const newEntry = createInstance('shr.base.Entry', {});
+      entryInfoSetter.call(inst, newEntry);
     }
     // Now find the setter for the property on the entry
     return findSetterForProperty(inst.entryInfo, property);
@@ -225,11 +230,11 @@ export const FHIRHelper = {
   },
 
   createReferenceWithoutObject: function(shrId, entryId, entryType) {
-    return new Reference(
-      new ShrId().withValue(shrId),
-      new EntryId().withValue(entryId),
-      new EntryType().withValue(entryType)
-    );
+     return new Reference(
+      createInstance('shr.base.ShrId', { Value: shrId }),
+      createInstance('shr.base.EntryId', { Value: entryId }),
+      createInstance('shr.base.EntryType', { Value: entryType })
+     );
   },
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-es6-export",
-  "version": "5.7.1",
+  "version": "5.7.2",
   "description": "Exports ES6 classes represent SHR data elements",
   "author": "",
   "license": "Apache-2.0",

--- a/test/es6FromFHIRJSONTest.js
+++ b/test/es6FromFHIRJSONTest.js
@@ -481,7 +481,7 @@ describe('#FromFHIR_STU3', () => {
         }
       };
 
-      ClassRegistry['shr.slicing']['Observation'] = anonymousSubclass;
+      ClassRegistry.set('shr.slicing', 'Observation', anonymousSubclass);
 
       const spyOriginalClass = chai.spy.on(Observation, 'fromFHIR');
       const spyReplacementClass = chai.spy.on(anonymousSubclass, 'fromFHIR');


### PR DESCRIPTION
Updates the class registry with a couple fixes identified from the initial implementation in FluxNotes.

1) Each class's `fromJSON` and `fromFHIR` should look up the class to instantiate in the class registry. (Alternative possible implementation, every class that is subclassed would have to implement `fromJSON`/`fromFHIR`)

2) Reworks the class registry to be a class itself and a singleton, with an initialize method to populate the registry. This prevents any circular dependency issues arising from the registry referencing each class, and each class referencing the registry.

3) A couple additional tweaks to json-helper. The `getNamespaceAndNameFromFhir` one was one I had made previously but forgot to commit. The `getNamespaceAndName` one makes the class registry calls a little cleaner.